### PR TITLE
Remove widget import from __init__

### DIFF
--- a/src/napari_metadata/__init__.py
+++ b/src/napari_metadata/__init__.py
@@ -3,6 +3,4 @@ try:
 except ImportError:
     __version__ = 'unknown'
 
-from ._widget import MetadataWidget
-
-__all__ = ('MetadataWidget',)
+__all__ = ()


### PR DESCRIPTION
Qt Dependent import at top level results in build fail on conda because of absence of pyqt in the environment 
https://github.com/conda-forge/staged-recipes/pull/32036