### PR TITLE
Add metadata dict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "numpy",
     "qtpy",
     "pint",
+    "superqt",
     "typing_extensions",  # only needed for python 3.10 import of Self
 ]
 dynamic = ["version"]

--- a/src/napari_metadata/layer_utils.py
+++ b/src/napari_metadata/layer_utils.py
@@ -1,9 +1,11 @@
 from collections.abc import Callable, Sequence
 from contextlib import suppress
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, cast, Any
 
 import numpy as np
 import pint
+
+from napari.utils.notifications import show_info
 
 if TYPE_CHECKING:
     from napari.components import ViewerModel
@@ -123,6 +125,17 @@ def get_layer_metadata_dict(
     if resolved_layer is None:
         return {}
     return resolved_layer.metadata
+
+
+def set_layer_metadata_dict(
+    viewer: 'ViewerModel',
+    layer: 'Layer | None' = None,
+    metadata: dict[Any, Any] | None = None,
+) -> None:
+    resolved_layer = resolve_layer(viewer, layer)
+    if resolved_layer is None:
+        return
+    resolved_layer.metadata = metadata if metadata is not None else {}
 
 
 def get_layer_data_shape(layer: 'Layer | None') -> tuple[int, ...]:

--- a/src/napari_metadata/layer_utils.py
+++ b/src/napari_metadata/layer_utils.py
@@ -116,6 +116,15 @@ def set_axes_translations(
         resolved_layer.translate = axes_translations
 
 
+def get_layer_metadata_dict(
+    viewer: 'ViewerModel', layer: 'Layer | None' = None
+) -> dict:
+    resolved_layer = resolve_layer(viewer, layer)
+    if resolved_layer is None:
+        return {}
+    return resolved_layer.metadata
+
+
 def get_layer_data_shape(layer: 'Layer | None') -> tuple[int, ...]:
     """Get the shape of the layer's data."""
     if layer is None:

--- a/src/napari_metadata/layer_utils.py
+++ b/src/napari_metadata/layer_utils.py
@@ -1,11 +1,9 @@
 from collections.abc import Callable, Sequence
 from contextlib import suppress
-from typing import TYPE_CHECKING, cast, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import pint
-
-from napari.utils.notifications import show_info
 
 if TYPE_CHECKING:
     from napari.components import ViewerModel

--- a/src/napari_metadata/resources/icons/add.svg
+++ b/src/napari_metadata/resources/icons/add.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
+<g id="Solid">
+	<g>
+		<path class="st0" d="M50,13.6c-20,0-36.3,16.3-36.3,36.3c0,20,16.3,36.3,36.3,36.3C70,86.3,86.3,70,86.3,50
+			C86.3,29.9,70,13.6,50,13.6z M50,79c-16,0-29.1-13-29.1-29.1c0-16,13-29.1,29.1-29.1C66,20.9,79,33.9,79,50C79,66,66,79,50,79z"/>
+		<polygon class="st0" points="53.6,31.8 46.3,31.8 46.3,46.3 31.8,46.3 31.8,53.6 46.3,53.6 46.3,68.1 53.6,68.1 53.6,53.6
+			68.1,53.6 68.1,46.3 53.6,46.3 		"/>
+	</g>
+</g>
+</svg>

--- a/src/napari_metadata/resources/icons/cancel.svg
+++ b/src/napari_metadata/resources/icons/cancel.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
+<rect x="45" y="21.3" transform="matrix(0.7112 -0.7029 0.7029 0.7112 -21.6791 50.024)" width="10" height="60.2"/>
+<rect x="19.9" y="46.4" transform="matrix(0.7113 -0.7029 0.7029 0.7113 -21.7284 49.9988)" width="60.2" height="10"/>
+</svg>

--- a/src/napari_metadata/resources/icons/confirm.svg
+++ b/src/napari_metadata/resources/icons/confirm.svg
@@ -1,0 +1,7 @@
+<svg version="1.1" id="Layer_1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 12 16">
+    <g>
+        <path d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/>
+    </g>
+</svg>

--- a/src/napari_metadata/resources/icons/delete.svg
+++ b/src/napari_metadata/resources/icons/delete.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
+<g id="Outline">
+	<g>
+		<path d="M26.5,74.2c0,3.7,3,6.8,6.8,6.8h33.8c3.7,0,6.8-3,6.8-6.8V33.7H26.5V74.2z M33.3,40.4h33.8v33.8H33.3V40.4z"/>
+		<polygon points="60.3,23.5 60.3,16.8 40.1,16.8 40.1,23.5 19.8,23.5 19.8,30.3 80.6,30.3 80.6,23.5 		"/>
+		<rect x="40.1" y="47.2" width="6.8" height="20.3"/>
+		<rect x="53.6" y="47.2" width="6.8" height="20.3"/>
+	</g>
+</g>
+</svg>

--- a/src/napari_metadata/resources/icons/edit.svg
+++ b/src/napari_metadata/resources/icons/edit.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.6, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
+<path d="M74.7,86.9H26.4c-6.9,0-12.2-5.4-12.2-12.2V26.4c0-6.9,5.4-12.2,12.2-12.2h48.1c6.9,0,12.2,5.4,12.2,12.2v48.1
+	C86.9,81.5,81.5,86.9,74.7,86.9z M28.9,72.1h43.2V28.9H28.9V72.1z"/>
+</svg>

--- a/src/napari_metadata/widgets/_axis.py
+++ b/src/napari_metadata/widgets/_axis.py
@@ -26,6 +26,7 @@ from qtpy.QtWidgets import (
     QLineEdit,
     QWidget,
 )
+from superqt import QEnumComboBox
 
 from napari_metadata.layer_utils import (
     get_axes_labels,
@@ -264,7 +265,7 @@ class AxisUnits(AxisComponentBase):
 
     def __init__(self, viewer: ViewerModel, parent_widget: QWidget) -> None:
         super().__init__(viewer, parent_widget)
-        self._type_comboboxes: list[QComboBox] = []
+        self._type_comboboxes: list[QEnumComboBox] = []
         self._unit_comboboxes: list[QComboBox] = []
         self._unit_line_edits: list[QLineEdit] = []
 
@@ -287,19 +288,18 @@ class AxisUnits(AxisComponentBase):
             unit_str = str(layer_units[i]) if i < len(layer_units) else ''
 
             # Type combobox (space / time / string)
-            type_cb = QComboBox(parent=self._parent_widget)
-            for axis_type in AxisUnitEnum:
-                type_cb.addItem(str(axis_type), axis_type)
+            type_cb = QEnumComboBox(
+                parent=self._parent_widget, enum_class=AxisUnitEnum
+            )
 
             # Unit combobox (curated pint units)
             unit_cb = QComboBox(parent=self._parent_widget)
             matched_type = self._populate_unit_combobox(unit_str, unit_cb)
-            type_index = type_cb.findData(
+            type_cb.setCurrentEnum(
                 matched_type
                 if matched_type is not None
                 else AxisUnitEnum.STRING
             )
-            type_cb.setCurrentIndex(type_index)
 
             # Free-form line edit for STRING type
             line_edit = QLineEdit(parent=self._parent_widget)
@@ -355,9 +355,7 @@ class AxisUnits(AxisComponentBase):
                         )
                     )
             with QSignalBlocker(self._type_comboboxes[i]):
-                self._type_comboboxes[i].setCurrentIndex(
-                    self._type_comboboxes[i].findText(str(matched_type))
-                )
+                self._type_comboboxes[i].setCurrentEnum(matched_type)
         self._sync_line_edit_texts()
         self._sync_visibilities()
 
@@ -420,11 +418,8 @@ class AxisUnits(AxisComponentBase):
     def _sync_visibilities(self) -> None:
         """Toggle unit combobox / line-edit visibility per axis type."""
         for i in range(len(self._type_comboboxes)):
-            axis_type = self._type_comboboxes[i].currentData()
-            show_combobox = (
-                isinstance(axis_type, AxisUnitEnum)
-                and axis_type != AxisUnitEnum.STRING
-            )
+            axis_type = self._type_comboboxes[i].currentEnum()
+            show_combobox = axis_type != AxisUnitEnum.STRING
             self._unit_comboboxes[i].setVisible(show_combobox)
             self._unit_line_edits[i].setVisible(not show_combobox)
 
@@ -441,8 +436,8 @@ class AxisUnits(AxisComponentBase):
         """Collect current unit selections and apply to the layer."""
         units: list[str | None] = []
         for i in range(len(self._type_comboboxes)):
-            axis_type = self._type_comboboxes[i].currentData()
-            if axis_type is None or axis_type == AxisUnitEnum.STRING:
+            axis_type = self._type_comboboxes[i].currentEnum()
+            if axis_type == AxisUnitEnum.STRING:
                 text = self._unit_line_edits[i].text().strip()
                 if text.lower() == 'none' or not text:
                     units.append(None)
@@ -466,9 +461,7 @@ class AxisUnits(AxisComponentBase):
             self._napari_viewer, resolve_layer(self._napari_viewer)
         )
         for i in range(len(self._type_comboboxes)):
-            axis_type = self._type_comboboxes[i].currentData()
-            if not isinstance(axis_type, AxisUnitEnum):
-                continue
+            axis_type = self._type_comboboxes[i].currentEnum()
             cfg = axis_type.value
             current_unit_str = (
                 str(current_units[i]) if i < len(current_units) else ''

--- a/src/napari_metadata/widgets/_dict_viewer.py
+++ b/src/napari_metadata/widgets/_dict_viewer.py
@@ -1,0 +1,54 @@
+"""
+Implement dictionary viewer widget
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from qtpy.QtWidgets import QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
+
+from napari_metadata.layer_utils import get_layer_metadata_dict
+
+if TYPE_CHECKING:
+    from napari.components import ViewerModel
+
+
+class MetadataDictViewer(QWidget):
+    def __init__(
+        self,
+        napari_viewer: ViewerModel,
+        parent: QWidget,
+        data: dict | None = None,
+    ):
+        super().__init__(parent=parent)
+        self._napari_viewer = napari_viewer
+        self._data = {}
+        self.tree = QTreeWidget(parent=self)
+        self._layout = QVBoxLayout(self)
+        self._layout.addWidget(self.tree)
+        self.setLayout(self._layout)
+        self.tree.setHeaderLabels(['Key', 'Value'])
+        self.set_data(data)
+
+    def set_data(self, data: dict | None):
+        if data is None:
+            data = {}
+        self._data = data
+        self.tree.clear()
+        self.fill_tree(data, self.tree)
+
+    def fill_tree(self, data: dict, parent: QTreeWidget | QTreeWidgetItem):
+        for key, value in data.items():
+            if isinstance(value, dict):
+                key_item = QTreeWidgetItem(parent, [key])
+                self.fill_tree(value, key_item)
+            elif isinstance(value, list):
+                key_item = QTreeWidgetItem(parent, [key])
+                for i, val in enumerate(value):
+                    self.fill_tree({str(i): val}, key_item)
+            else:
+                QTreeWidgetItem(parent, [key, str(value)])
+
+    def load_layer_dict(self) -> None:
+        self.set_data(get_layer_metadata_dict(self._napari_viewer))

--- a/src/napari_metadata/widgets/_dict_viewer.py
+++ b/src/napari_metadata/widgets/_dict_viewer.py
@@ -43,6 +43,7 @@ class MetadataDictViewer(QWidget):
         self._layout.addWidget(self.tree)
         self.setLayout(self._layout)
         self.tree.setHeaderLabels(['Key', 'Value'])
+        self.tree.setIndentation(28)
         self.tree.setStyleSheet(
             'QTreeWidget::item { padding-top: 4px; padding-bottom: 4px; }'
         )
@@ -72,8 +73,9 @@ class MetadataDictViewer(QWidget):
             self._add_dict_add_row(parent, index_width, is_root=True)
         else:
             index_width = getattr(self, '_index_label_width', None)
-            for key, value in data.items():
-                self._fill_tree_item(parent, key, value, None, index_width)
+            items = enumerate(data.items(), start=0)
+            for index, (key, value) in items:
+                self._fill_tree_item(parent, key, value, index, index_width)
             self._add_dict_add_row(parent, index_width, is_root=False)
 
     def _fill_tree_item(
@@ -94,7 +96,7 @@ class MetadataDictViewer(QWidget):
             self._set_key_widget(key_item, key, index, index_width)
             type_name = 'list' if isinstance(value, list) else 'tuple'
             self._set_value_type_widget(key_item, type_name)
-            self._fill_sequence_items(value, key_item, index_width)
+            self._fill_sequence_items(value, key_item, index_width, type_name)
         else:
             value_item = QTreeWidgetItem(parent, ['', ''])
             self._set_key_widget(value_item, key, index, index_width)
@@ -122,26 +124,40 @@ class MetadataDictViewer(QWidget):
         self,
         item: QTreeWidgetItem,
         index: int,
+        entry_type: str,
         index_width: int | None = None,
     ) -> None:
-        label = QLabel(f'[{index}]', self)
+        container = QWidget(self)
+        layout = QHBoxLayout(container)
+        layout.setContentsMargins(0, 0, 8, 0)
+        layout.setSpacing(4)
+        label = QLabel(f'[{index}]', container)
         label.setAlignment(
-            Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
+            Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
         )
         if index_width is not None:
             label.setMinimumWidth(index_width)
-        label.setSizePolicy(
+        entry_label = QLineEdit(f'{entry_type} entry', container)
+        entry_label.setReadOnly(True)
+        entry_label.setEnabled(False)
+        layout.addWidget(label)
+        layout.addWidget(entry_label)
+        container.setSizePolicy(
             QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
         )
-        label.setContentsMargins(0, 0, 3, 0)
-        self.tree.setItemWidget(item, 0, label)
+        self.tree.setItemWidget(item, 0, container)
         self._update_item_height(item)
 
-    def _set_add_row_widget(self, item: QTreeWidgetItem) -> None:
+    def _set_add_row_widget(
+        self,
+        item: QTreeWidgetItem,
+        sequence_type: str,
+        index_width: int | None,
+    ) -> None:
         container = QWidget(self)
         layout = QHBoxLayout(container)
-        layout.setContentsMargins(0, 0, 3, 0)
-        layout.setSpacing(0)
+        layout.setContentsMargins(0, 0, 8, 0)
+        layout.setSpacing(4)
         add_button = QPushButton('Add', container)
         icon = _load_icon('add.svg')
         if not icon.isNull():
@@ -150,23 +166,63 @@ class MetadataDictViewer(QWidget):
             add_button.setToolTip('Add')
             add_button.setIconSize(QSize(18, 18))
         add_button.setFixedSize(QSize(26, 26))
-        layout.addWidget(add_button, alignment=Qt.AlignmentFlag.AlignRight)
+        entry_label = QLineEdit(f'New {sequence_type} entry', container)
+        entry_label.setReadOnly(True)
+        entry_label.setEnabled(False)
+        layout.addWidget(add_button)
+        layout.addWidget(entry_label)
         container.setSizePolicy(
             QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
         )
         self.tree.setItemWidget(item, 0, container)
-        combo = QComboBox(self)
-        combo.addItems(['number', 'string', 'tuple', 'list', 'dictionary'])
-        combo_container = QWidget(self)
-        combo_layout = QHBoxLayout(combo_container)
-        combo_layout.setContentsMargins(8, 0, 0, 0)
-        combo_layout.setSpacing(0)
-        combo_layout.addWidget(combo)
-        combo_container.setSizePolicy(
-            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
-        )
+        combo_container = self._create_add_value_widget()
         self.tree.setItemWidget(item, 1, combo_container)
         self._update_item_height(item)
+
+    def _create_add_value_widget(self) -> QWidget:
+        container = QWidget(self)
+        layout = QHBoxLayout(container)
+        layout.setContentsMargins(8, 0, 0, 0)
+        layout.setSpacing(4)
+        combo_width = 116
+        value_edit = QLineEdit(container)
+        type_label = QLabel('', container)
+        type_label.setStyleSheet('color: gray; font-style: italic;')
+        type_label.setAlignment(
+            Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
+        )
+        combo = QComboBox(container)
+        combo.addItems(
+            ['number', 'string', 'tuple', 'list', 'dictionary', 'none']
+        )
+        combo.setFixedWidth(combo_width)
+        layout.addWidget(value_edit)
+        layout.addWidget(type_label)
+        layout.addWidget(combo)
+        container.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
+        )
+
+        def update_value_widget(selection: str) -> None:
+            if selection in ('number', 'string'):
+                value_edit.setVisible(True)
+                type_label.setVisible(False)
+                if value_edit.text() == 'None':
+                    value_edit.setText('')
+                return
+            if selection == 'none':
+                value_edit.setVisible(False)
+                type_label.setText('NA')
+                type_label.setVisible(True)
+                return
+            value_edit.setVisible(False)
+            label_text = 'dict' if selection == 'dictionary' else selection
+            type_label.setText(label_text)
+            type_label.setVisible(True)
+
+        combo.currentTextChanged.connect(update_value_widget)
+        update_value_widget(combo.currentText())
+        return container
 
     def _add_dict_add_row(
         self,
@@ -184,11 +240,6 @@ class MetadataDictViewer(QWidget):
         key_layout = QHBoxLayout(key_container)
         key_layout.setContentsMargins(0, 0, 8, 0)
         key_layout.setSpacing(4)
-        if index_width is not None:
-            spacer = QLabel('', key_container)
-            spacer_width = index_width if is_root else index_width + 5
-            spacer.setFixedWidth(spacer_width)
-            key_layout.addWidget(spacer)
         add_button = QPushButton('Add', key_container)
         icon = _load_icon('add.svg')
         if not icon.isNull():
@@ -197,25 +248,21 @@ class MetadataDictViewer(QWidget):
             add_button.setToolTip('Add')
             add_button.setIconSize(QSize(18, 18))
         add_button.setFixedSize(QSize(26, 26))
+        key_edit = QLineEdit(key_container)
         key_combo = QComboBox(key_container)
         key_combo.addItems(['number', 'string'])
+        key_combo.setSizeAdjustPolicy(
+            QComboBox.SizeAdjustPolicy.AdjustToContents
+        )
         key_layout.addWidget(add_button)
+        key_layout.addWidget(key_edit)
         key_layout.addWidget(key_combo)
         key_container.setSizePolicy(
             QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
         )
         self.tree.setItemWidget(item, 0, key_container)
 
-        value_combo = QComboBox(self)
-        value_combo.addItems(['number', 'string', 'tuple', 'list', 'dictionary'])
-        value_container = QWidget(self)
-        value_layout = QHBoxLayout(value_container)
-        value_layout.setContentsMargins(8, 0, 0, 0)
-        value_layout.setSpacing(0)
-        value_layout.addWidget(value_combo)
-        value_container.setSizePolicy(
-            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
-        )
+        value_container = self._create_add_value_widget()
         self.tree.setItemWidget(item, 1, value_container)
         self._update_item_height(item)
 
@@ -224,23 +271,28 @@ class MetadataDictViewer(QWidget):
         values: list | tuple,
         parent: QTreeWidgetItem,
         index_width: int | None,
+        sequence_type: str,
     ) -> None:
         for i, val in enumerate(values):
             index_item = QTreeWidgetItem(parent, ['', ''])
-            self._set_index_key_widget(index_item, i, index_width)
+            self._set_index_key_widget(
+                index_item, i, sequence_type, index_width
+            )
             if isinstance(val, dict):
                 self._set_value_type_widget(index_item, 'dict')
                 self.fill_tree(val, index_item)
             elif isinstance(val, (list, tuple)):
                 nested_type = 'list' if isinstance(val, list) else 'tuple'
                 self._set_value_type_widget(index_item, nested_type)
-                self._fill_sequence_items(val, index_item, index_width)
+                self._fill_sequence_items(
+                    val, index_item, index_width, nested_type
+                )
             else:
                 value_widget = ValueWidget(val, self)
                 self.tree.setItemWidget(index_item, 1, value_widget)
                 self._update_item_height(index_item)
         add_item = QTreeWidgetItem(parent, ['', ''])
-        self._set_add_row_widget(add_item)
+        self._set_add_row_widget(add_item, sequence_type, index_width)
 
     def _set_value_type_widget(
         self, item: QTreeWidgetItem, type_name: str
@@ -264,6 +316,9 @@ class MetadataDictViewer(QWidget):
     def _set_item_selected(
         self, item: QTreeWidgetItem, selected: bool
     ) -> None:
+        key_widget = self.tree.itemWidget(item, 0)
+        if isinstance(key_widget, KeyWidget):
+            key_widget.set_selected(selected)
         value_widget = self.tree.itemWidget(item, 1)
         if isinstance(value_widget, ValueWidget):
             value_widget.set_selected(selected)
@@ -285,6 +340,8 @@ class MetadataDictViewer(QWidget):
         if not heights:
             return
         height = max(heights) + 8
+        if item.parent() is None:
+            height += 6
         item.setSizeHint(0, QSize(0, height))
         item.setSizeHint(1, QSize(0, height))
 
@@ -310,6 +367,7 @@ class KeyWidget(QWidget):
         self._is_editable = isinstance(key, str) or (
             isinstance(key, (int, float)) and not isinstance(key, bool)
         )
+        self._type_label_color: str | None = None
         self._layout = QHBoxLayout(self)
         self._layout.setContentsMargins(0, 0, 8, 0)
         self._layout.setSpacing(4)
@@ -320,50 +378,114 @@ class KeyWidget(QWidget):
             self._layout.addWidget(self.index_label)
         elif index_width is not None:
             spacer = QLabel('', self)
-            spacer.setFixedWidth(index_width + 5)
+            spacer.setFixedWidth(index_width)
             self._layout.addWidget(spacer)
         if self._is_editable:
             self.key_edit = QLineEdit(self._original_key, self)
             self.key_edit.setReadOnly(True)
+            if isinstance(key, str):
+                type_text = 'string'
+                self._type_label_color = '#e68c2c'
+            else:
+                type_text = 'number'
+                self._type_label_color = '#4091ed'
+            self._original_type = type_text
         else:
             self.key_label = QLabel(self._original_key, self)
-        self.edit_button = QPushButton('Edit', self)
-        self.edit_button.setSizePolicy(
-            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
-        )
-        self.edit_button.setCheckable(self._is_editable)
+            type_text = 'Non-editable'
+        self.type_combo = QComboBox(self)
+        self.type_combo.addItems(['number', 'string'])
+        self.type_combo.setVisible(False)
         self.delete_button = QPushButton('Delete', self)
+        self.type_label = QLabel(type_text, self)
+        if self._is_editable and self._type_label_color is not None:
+            self.type_label.setStyleSheet(f'color: {self._type_label_color};')
+            self.type_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            self.type_label.setFixedWidth(56)
+        else:
+            self.type_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            self.type_label.setStyleSheet('color: gray; font-style: italic;')
+            self.type_label.setFixedWidth(86)
         if self._is_editable:
+            self.edit_button = QPushButton('Edit', self)
+            self.edit_button.setSizePolicy(
+                QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
+            )
+            self.edit_button.setCheckable(True)
             self._apply_icon(
                 self.edit_button, 'edit.svg', 'Edit', QSize(14, 14)
             )
-        else:
-            self.edit_button.setEnabled(False)
-            self.edit_button.setText('NE')
-            self.edit_button.setToolTip('Non-editable data')
-            self.edit_button.setStyleSheet('color: gray; font-style: italic;')
-            self.edit_button.setFixedSize(QSize(26, 26))
+        if self._is_editable:
+            pass
         self._apply_icon(
             self.delete_button, 'delete.svg', 'Delete', QSize(18, 18)
         )
-        self._layout.addWidget(self.edit_button)
-        self._layout.addWidget(self.delete_button)
         if self._is_editable:
             self._layout.addWidget(self.key_edit)
             self.key_edit.editingFinished.connect(self._on_editing_finished)
-            self.edit_button.toggled.connect(
-                lambda checked: self.key_edit.setReadOnly(not checked)
-            )
+            self.edit_button.toggled.connect(self._on_edit_toggled)
         else:
             self._layout.addWidget(self.key_label)
+        self._layout.addWidget(self.type_label)
+        self._layout.addWidget(self.type_combo)
+        if self._is_editable:
+            self._layout.addWidget(self.edit_button)
+        self._layout.addWidget(self.delete_button)
+
+    def _on_edit_toggled(self, checked: bool) -> None:
+        self.key_edit.setReadOnly(not checked)
+        self.type_label.setVisible(not checked)
+        self.type_combo.setVisible(checked)
+        if checked:
+            self.type_combo.setCurrentText(self.type_label.text())
 
     def _on_editing_finished(self) -> None:
         new_key = self.key_edit.text()
+        selected_type = self.type_combo.currentText()
+        if selected_type == 'number':
+            try:
+                float(new_key)
+            except ValueError:
+                self.key_edit.setText(self._original_key)
+                self.type_combo.setCurrentText(self._original_type)
+                self._apply_type_selection(self._original_type)
+                self.edit_button.setChecked(False)
+                return
+        self.edit_button.setChecked(False)
         if new_key == self._original_key:
+            self._apply_type_selection(selected_type)
             return
         old_key = self._original_key
         self._original_key = new_key
         self.key_changed.emit(old_key, new_key)
+        self._apply_type_selection(selected_type)
+
+    def _apply_type_selection(self, selected_type: str | None = None) -> None:
+        if selected_type is None:
+            selected_type = self.type_combo.currentText()
+        if selected_type == 'string':
+            self._type_label_color = '#e68c2c'
+        else:
+            self._type_label_color = '#4091ed'
+        self._original_type = selected_type
+        self.type_label.setText(selected_type)
+        self.type_label.setStyleSheet(f'color: {self._type_label_color};')
+        self.type_label.setVisible(True)
+        self.type_combo.setVisible(False)
+
+    def set_selected(self, selected: bool) -> None:
+        if self._is_editable and self._type_label_color is not None:
+            if selected:
+                self.type_label.setStyleSheet('color: black;')
+            else:
+                self.type_label.setStyleSheet(
+                    f'color: {self._type_label_color};'
+                )
+            return
+        if selected:
+            self.type_label.setStyleSheet('color: black; font-style: italic;')
+        else:
+            self.type_label.setStyleSheet('color: gray; font-style: italic;')
 
     def _apply_icon(
         self,
@@ -388,13 +510,15 @@ class ValueWidget(QWidget):
         self._layout.setContentsMargins(8, 0, 0, 0)
         self._layout.setSpacing(4)
         self._editable = False
+        self._type_label_color: str | None = None
 
         if isinstance(value, str):
             self.value_edit = QLineEdit(value, self)
             self.value_edit.setReadOnly(True)
             self.type_label = QLabel('string', self)
-            self.type_label.setStyleSheet('color: #e68c2c;')
-            self.type_label.setAlignment(Qt.AlignmentFlag.AlignHCenter)
+            self._type_label_color = '#e68c2c'
+            self.type_label.setStyleSheet(f'color: {self._type_label_color};')
+            self.type_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
             self.type_label.setFixedWidth(56)
             self._layout.addWidget(self.value_edit)
             self._layout.addWidget(self.type_label)
@@ -404,8 +528,20 @@ class ValueWidget(QWidget):
             self.value_edit = QLineEdit(str(value), self)
             self.value_edit.setReadOnly(True)
             self.type_label = QLabel('number', self)
-            self.type_label.setStyleSheet('color: #4091ed;')
-            self.type_label.setAlignment(Qt.AlignmentFlag.AlignHCenter)
+            self._type_label_color = '#4091ed'
+            self.type_label.setStyleSheet(f'color: {self._type_label_color};')
+            self.type_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            self.type_label.setFixedWidth(56)
+            self._layout.addWidget(self.value_edit)
+            self._layout.addWidget(self.type_label)
+            self._add_controls(editable=True)
+            self._editable = True
+        elif value is None:
+            self.value_edit = QLineEdit('None', self)
+            self.value_edit.setReadOnly(True)
+            self.type_label = QLabel('NA', self)
+            self.type_label.setStyleSheet('color: black;')
+            self.type_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
             self.type_label.setFixedWidth(56)
             self._layout.addWidget(self.value_edit)
             self._layout.addWidget(self.type_label)
@@ -426,7 +562,13 @@ class ValueWidget(QWidget):
             self._add_controls(editable=False)
 
     def set_selected(self, selected: bool) -> None:
-        if self._editable:
+        if self._editable and self._type_label_color is not None:
+            if selected:
+                self.type_label.setStyleSheet('color: black;')
+            else:
+                self.type_label.setStyleSheet(
+                    f'color: {self._type_label_color};'
+                )
             return
         if selected:
             self.type_label.setStyleSheet('color: black; font-style: italic;')
@@ -445,9 +587,54 @@ class ValueWidget(QWidget):
         self._layout.addWidget(self.edit_button)
         self._layout.addWidget(self.delete_button)
         if editable:
-            self.edit_button.toggled.connect(
-                lambda checked: self.value_edit.setReadOnly(not checked)
+            self.type_combo = QComboBox(self)
+            self.type_combo.addItems(
+                ['number', 'string', 'tuple', 'list', 'dictionary', 'none']
             )
+            self.type_combo.setVisible(False)
+            self._layout.insertWidget(1, self.type_combo)
+            self.edit_button.toggled.connect(self._on_edit_toggled)
+
+    def _on_edit_toggled(self, checked: bool) -> None:
+        self.value_edit.setReadOnly(not checked)
+        self.type_label.setVisible(not checked)
+        self.type_combo.setVisible(checked)
+        if checked:
+            current_type = self.type_label.text().lower()
+            if current_type == 'na':
+                current_type = 'none'
+            elif current_type == 'non-editable':
+                current_type = 'string'
+            self.type_combo.setCurrentText(current_type)
+            self._apply_value_type_selection(current_type)
+        else:
+            self._apply_value_type_selection(self.type_combo.currentText())
+
+    def _apply_value_type_selection(self, selected_type: str) -> None:
+        if selected_type in ('string', 'number'):
+            self.value_edit.setVisible(True)
+            self.type_label.setVisible(False)
+            return
+        self.value_edit.setVisible(False)
+        if selected_type == 'dictionary':
+            label_text = 'dict'
+            label_color = 'gray'
+            label_style = 'font-style: italic;'
+        elif selected_type == 'tuple':
+            label_text = 'tuple'
+            label_color = 'gray'
+            label_style = 'font-style: italic;'
+        elif selected_type == 'list':
+            label_text = 'list'
+            label_color = 'gray'
+            label_style = 'font-style: italic;'
+        else:
+            label_text = 'NA'
+            label_color = 'black'
+            label_style = ''
+        self.type_label.setText(label_text)
+        self.type_label.setStyleSheet(f'color: {label_color}; {label_style}')
+        self.type_label.setVisible(True)
 
     def _apply_icon(
         self,
@@ -463,6 +650,11 @@ class ValueWidget(QWidget):
             button.setToolTip(tooltip)
             button.setIconSize(icon_size)
         button.setFixedSize(QSize(26, 26))
+
+    def _recreate_dictionary(self) -> None:
+        print('')
+        print('Updating dictionary')
+        return
 
 
 def _load_icon(name: str) -> QIcon:

--- a/src/napari_metadata/widgets/_dict_viewer.py
+++ b/src/napari_metadata/widgets/_dict_viewer.py
@@ -7,13 +7,14 @@ from __future__ import annotations
 from importlib import resources
 from typing import TYPE_CHECKING
 
-from qtpy.QtCore import Signal, QSize, Qt
+from napari.utils.notifications import show_info
+from qtpy.QtCore import QSize, Qt, Signal
 from qtpy.QtGui import QFontMetrics, QIcon
 from qtpy.QtWidgets import (
+    QComboBox,
     QHBoxLayout,
     QLabel,
     QLineEdit,
-    QComboBox,
     QPushButton,
     QSizePolicy,
     QTreeWidget,
@@ -26,7 +27,6 @@ from napari_metadata.layer_utils import (
     get_layer_metadata_dict,
     set_layer_metadata_dict,
 )
-from napari.utils.notifications import show_info
 
 if TYPE_CHECKING:
     from napari.components import ViewerModel
@@ -589,7 +589,9 @@ class MetadataDictViewer(QWidget):
             if isinstance(existing_key, dict):
                 existing_key = existing_key.get('key')
             if existing_key == key_value:
-                show_info(f'Key already exists in this dictionary: {existing_key}')
+                show_info(
+                    f'Key already exists in this dictionary: {existing_key}'
+                )
                 return
         index_width = getattr(self, '_index_label_width', None)
         insert_index = (

--- a/src/napari_metadata/widgets/_dict_viewer.py
+++ b/src/napari_metadata/widgets/_dict_viewer.py
@@ -22,7 +22,11 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from napari_metadata.layer_utils import get_layer_metadata_dict
+from napari_metadata.layer_utils import (
+    get_layer_metadata_dict,
+    set_layer_metadata_dict,
+)
+from napari.utils.notifications import show_info
 
 if TYPE_CHECKING:
     from napari.components import ViewerModel
@@ -325,7 +329,9 @@ class MetadataDictViewer(QWidget):
                 'key_combo': key_combo,
             },
         )
-        item.setData(1, Qt.ItemDataRole.UserRole, {'add_row': True, **value_widgets})
+        item.setData(
+            1, Qt.ItemDataRole.UserRole, {'add_row': True, **value_widgets}
+        )
         add_button.clicked.connect(lambda: self._add_dict_entry(item))
         self._update_item_height(item)
 
@@ -381,6 +387,41 @@ class MetadataDictViewer(QWidget):
         value_widget = self.tree.itemWidget(item, 1)
         if isinstance(value_widget, ValueWidget):
             value_widget.set_selected(selected)
+
+    def _iter_items(self) -> list[QTreeWidgetItem]:
+        items: list[QTreeWidgetItem] = []
+        for i in range(self.tree.topLevelItemCount()):
+            items.append(self.tree.topLevelItem(i))
+        index = 0
+        while index < len(items):
+            item = items[index]
+            for i in range(item.childCount()):
+                items.append(item.child(i))
+            index += 1
+        return items
+
+    def _find_item_by_widget(
+        self, widget: QWidget, column: int
+    ) -> QTreeWidgetItem | None:
+        for item in self._iter_items():
+            if self.tree.itemWidget(item, column) is widget:
+                return item
+        return None
+
+    def _delete_item_for_widget(self, widget: QWidget, column: int) -> None:
+        item = self._find_item_by_widget(widget, column)
+        if item is None:
+            return
+        parent = item.parent()
+        if parent is None:
+            index = self.tree.indexOfTopLevelItem(item)
+            if index >= 0:
+                self.tree.takeTopLevelItem(index)
+        else:
+            index = parent.indexOfChild(item)
+            if index >= 0:
+                parent.takeChild(index)
+        self._recreate_dictionary()
 
     def _request_edit(self, widget: KeyWidget | ValueWidget) -> None:
         if self._editing_widget is widget:
@@ -492,7 +533,9 @@ class MetadataDictViewer(QWidget):
             return
         new_item = QTreeWidgetItem(['', ''])
         self._insert_child(parent, insert_index, new_item)
-        self._set_index_key_widget(new_item, entry_index, sequence_type, index_width)
+        self._set_index_key_widget(
+            new_item, entry_index, sequence_type, index_width
+        )
         if value_type == 'dictionary':
             self._set_value_type_widget(new_item, 'dict')
             self._set_value_item_data(new_item, value)
@@ -530,6 +573,24 @@ class MetadataDictViewer(QWidget):
                 return
         else:
             key_value = key_text
+        for i in range(
+            parent.childCount()
+            if isinstance(parent, QTreeWidgetItem)
+            else self.tree.topLevelItemCount()
+        ):
+            child = (
+                parent.child(i)
+                if isinstance(parent, QTreeWidgetItem)
+                else self.tree.topLevelItem(i)
+            )
+            if self._is_add_row(child):
+                continue
+            existing_key = child.data(0, Qt.ItemDataRole.UserRole) or {}
+            if isinstance(existing_key, dict):
+                existing_key = existing_key.get('key')
+            if existing_key == key_value:
+                show_info(f'Key already exists in this dictionary: {existing_key}')
+                return
         index_width = getattr(self, '_index_label_width', None)
         insert_index = (
             parent.indexOfChild(add_item)
@@ -654,7 +715,8 @@ class MetadataDictViewer(QWidget):
                 continue
             key = parse_key(item)
             result[key] = parse_value(item)
-        print(result)
+        set_layer_metadata_dict(self._napari_viewer, None, result)
+        self.load_layer_dict()
 
 
 class KeyWidget(QWidget):
@@ -668,7 +730,9 @@ class KeyWidget(QWidget):
         parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent=parent)
-        self._viewer = parent if isinstance(parent, MetadataDictViewer) else None
+        self._viewer = (
+            parent if isinstance(parent, MetadataDictViewer) else None
+        )
         self._original_key = str(key)
         self._is_editable = isinstance(key, str) or (
             isinstance(key, (int, float)) and not isinstance(key, bool)
@@ -731,7 +795,7 @@ class KeyWidget(QWidget):
         self._layout.addWidget(self.type_combo)
         self._layout.addWidget(self.edit_button)
         self._layout.addWidget(self.delete_button)
-        self.delete_button.clicked.connect(self._on_cancel_clicked)
+        self.delete_button.clicked.connect(self._on_delete_clicked)
 
     def _on_edit_toggled(self, checked: bool) -> None:
         if checked and self._viewer is not None:
@@ -780,6 +844,13 @@ class KeyWidget(QWidget):
         )
         if self._viewer is not None:
             self._viewer._end_edit(self)
+
+    def _on_delete_clicked(self) -> None:
+        if self.edit_button.isChecked():
+            self._on_cancel_clicked()
+            return
+        if self._viewer is not None:
+            self._viewer._delete_item_for_widget(self, 0)
 
     def _commit_edit(self) -> None:
         new_key = self.key_edit.text()
@@ -873,7 +944,9 @@ class ValueWidget(QWidget):
         container_type: str | None = None,
     ) -> None:
         super().__init__(parent=parent)
-        self._viewer = parent if isinstance(parent, MetadataDictViewer) else None
+        self._viewer = (
+            parent if isinstance(parent, MetadataDictViewer) else None
+        )
         self._layout = QHBoxLayout(self)
         self._layout.setContentsMargins(16, 0, 0, 0)
         self._layout.setSpacing(4)
@@ -985,11 +1058,15 @@ class ValueWidget(QWidget):
         if selected:
             self.type_label.setStyleSheet('color: black; font-style: italic;')
             if hasattr(self, 'value_label') and self.value_label is not None:
-                self.value_label.setStyleSheet('color: black; font-style: italic;')
+                self.value_label.setStyleSheet(
+                    'color: black; font-style: italic;'
+                )
         else:
             self.type_label.setStyleSheet('color: gray; font-style: italic;')
             if hasattr(self, 'value_label') and self.value_label is not None:
-                self.value_label.setStyleSheet('color: gray; font-style: italic;')
+                self.value_label.setStyleSheet(
+                    'color: gray; font-style: italic;'
+                )
 
     def _add_controls(self, editable: bool) -> None:
         self.edit_button = QPushButton('Edit', self)
@@ -1006,7 +1083,15 @@ class ValueWidget(QWidget):
         if editable:
             self.type_combo = QComboBox(self)
             self.type_combo.addItems(
-                ['number', 'string', 'bool', 'tuple', 'list', 'dictionary', 'none']
+                [
+                    'number',
+                    'string',
+                    'bool',
+                    'tuple',
+                    'list',
+                    'dictionary',
+                    'none',
+                ]
             )
             self.type_combo.setSizeAdjustPolicy(
                 QComboBox.SizeAdjustPolicy.AdjustToContents
@@ -1027,7 +1112,7 @@ class ValueWidget(QWidget):
             self.type_combo.currentTextChanged.connect(
                 self._apply_value_type_selection
             )
-        self.delete_button.clicked.connect(self._on_cancel_clicked)
+        self.delete_button.clicked.connect(self._on_delete_clicked)
 
     def _on_edit_toggled(self, checked: bool) -> None:
         if checked and self._viewer is not None:
@@ -1037,7 +1122,9 @@ class ValueWidget(QWidget):
         self.type_combo.setVisible(checked)
         self.delete_button.setVisible(not checked)
         if checked:
-            current_type = self._original_type_text or self.type_label.text().lower()
+            current_type = (
+                self._original_type_text or self.type_label.text().lower()
+            )
             if current_type == 'na':
                 current_type = 'none'
             elif current_type == 'non-editable':
@@ -1094,6 +1181,15 @@ class ValueWidget(QWidget):
         )
         if self._viewer is not None:
             self._viewer._end_edit(self)
+
+    def _on_delete_clicked(self) -> None:
+        if not self._editable:
+            return
+        if self.edit_button.isChecked():
+            self._on_cancel_clicked()
+            return
+        if self._viewer is not None:
+            self._viewer._delete_item_for_widget(self, 1)
 
     def _apply_value_type_selection(self, selected_type: str) -> None:
         if hasattr(self, 'value_label') and self.value_label is not None:
@@ -1253,7 +1349,10 @@ class ValueWidget(QWidget):
             self.edit_button.setIcon(self._edit_icon)
 
     def _commit_edit(self) -> None:
-        if self._original_value_text is None or self._original_type_text is None:
+        if (
+            self._original_value_text is None
+            or self._original_type_text is None
+        ):
             return
         selected_type = self.type_combo.currentText()
         if selected_type == 'number':
@@ -1322,8 +1421,6 @@ class ValueWidget(QWidget):
         if hasattr(self, 'value_label'):
             return self.value_label.text()
         return None
-
-
 
 
 def _load_icon(name: str) -> QIcon:

--- a/src/napari_metadata/widgets/_dict_viewer.py
+++ b/src/napari_metadata/widgets/_dict_viewer.py
@@ -13,6 +13,7 @@ from qtpy.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QLineEdit,
+    QComboBox,
     QPushButton,
     QSizePolicy,
     QTreeWidget,
@@ -65,13 +66,15 @@ class MetadataDictViewer(QWidget):
         if is_root:
             index_width = self._get_index_label_width(len(data))
             self._index_label_width = index_width
-            items = enumerate(data.items(), start=1)
+            items = enumerate(data.items(), start=0)
             for index, (key, value) in items:
                 self._fill_tree_item(parent, key, value, index, index_width)
+            self._add_dict_add_row(parent, index_width, is_root=True)
         else:
             index_width = getattr(self, '_index_label_width', None)
             for key, value in data.items():
                 self._fill_tree_item(parent, key, value, None, index_width)
+            self._add_dict_add_row(parent, index_width, is_root=False)
 
     def _fill_tree_item(
         self,
@@ -134,6 +137,88 @@ class MetadataDictViewer(QWidget):
         self.tree.setItemWidget(item, 0, label)
         self._update_item_height(item)
 
+    def _set_add_row_widget(self, item: QTreeWidgetItem) -> None:
+        container = QWidget(self)
+        layout = QHBoxLayout(container)
+        layout.setContentsMargins(0, 0, 3, 0)
+        layout.setSpacing(0)
+        add_button = QPushButton('Add', container)
+        icon = _load_icon('add.svg')
+        if not icon.isNull():
+            add_button.setIcon(icon)
+            add_button.setText('')
+            add_button.setToolTip('Add')
+            add_button.setIconSize(QSize(18, 18))
+        add_button.setFixedSize(QSize(26, 26))
+        layout.addWidget(add_button, alignment=Qt.AlignmentFlag.AlignRight)
+        container.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
+        )
+        self.tree.setItemWidget(item, 0, container)
+        combo = QComboBox(self)
+        combo.addItems(['number', 'string', 'tuple', 'list', 'dictionary'])
+        combo_container = QWidget(self)
+        combo_layout = QHBoxLayout(combo_container)
+        combo_layout.setContentsMargins(8, 0, 0, 0)
+        combo_layout.setSpacing(0)
+        combo_layout.addWidget(combo)
+        combo_container.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
+        )
+        self.tree.setItemWidget(item, 1, combo_container)
+        self._update_item_height(item)
+
+    def _add_dict_add_row(
+        self,
+        parent: QTreeWidget | QTreeWidgetItem,
+        index_width: int | None,
+        is_root: bool,
+    ) -> None:
+        add_item = QTreeWidgetItem(parent, ['', ''])
+        self._set_dict_add_row_widget(add_item, index_width, is_root)
+
+    def _set_dict_add_row_widget(
+        self, item: QTreeWidgetItem, index_width: int | None, is_root: bool
+    ) -> None:
+        key_container = QWidget(self)
+        key_layout = QHBoxLayout(key_container)
+        key_layout.setContentsMargins(0, 0, 8, 0)
+        key_layout.setSpacing(4)
+        if index_width is not None:
+            spacer = QLabel('', key_container)
+            spacer_width = index_width if is_root else index_width + 5
+            spacer.setFixedWidth(spacer_width)
+            key_layout.addWidget(spacer)
+        add_button = QPushButton('Add', key_container)
+        icon = _load_icon('add.svg')
+        if not icon.isNull():
+            add_button.setIcon(icon)
+            add_button.setText('')
+            add_button.setToolTip('Add')
+            add_button.setIconSize(QSize(18, 18))
+        add_button.setFixedSize(QSize(26, 26))
+        key_combo = QComboBox(key_container)
+        key_combo.addItems(['number', 'string'])
+        key_layout.addWidget(add_button)
+        key_layout.addWidget(key_combo)
+        key_container.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
+        )
+        self.tree.setItemWidget(item, 0, key_container)
+
+        value_combo = QComboBox(self)
+        value_combo.addItems(['number', 'string', 'tuple', 'list', 'dictionary'])
+        value_container = QWidget(self)
+        value_layout = QHBoxLayout(value_container)
+        value_layout.setContentsMargins(8, 0, 0, 0)
+        value_layout.setSpacing(0)
+        value_layout.addWidget(value_combo)
+        value_container.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
+        )
+        self.tree.setItemWidget(item, 1, value_container)
+        self._update_item_height(item)
+
     def _fill_sequence_items(
         self,
         values: list | tuple,
@@ -154,6 +239,8 @@ class MetadataDictViewer(QWidget):
                 value_widget = ValueWidget(val, self)
                 self.tree.setItemWidget(index_item, 1, value_widget)
                 self._update_item_height(index_item)
+        add_item = QTreeWidgetItem(parent, ['', ''])
+        self._set_add_row_widget(add_item)
 
     def _set_value_type_widget(
         self, item: QTreeWidgetItem, type_name: str
@@ -163,7 +250,15 @@ class MetadataDictViewer(QWidget):
         value_label.setAlignment(
             Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
         )
-        self.tree.setItemWidget(item, 1, value_label)
+        container = QWidget(self)
+        layout = QHBoxLayout(container)
+        layout.setContentsMargins(8, 0, 0, 0)
+        layout.setSpacing(0)
+        layout.addWidget(value_label)
+        container.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
+        )
+        self.tree.setItemWidget(item, 1, container)
         self._update_item_height(item)
 
     def _set_item_selected(
@@ -219,7 +314,7 @@ class KeyWidget(QWidget):
         self._layout.setContentsMargins(0, 0, 8, 0)
         self._layout.setSpacing(4)
         if index is not None:
-            self.index_label = QLabel(str(index), self)
+            self.index_label = QLabel(f'[{index}]', self)
             if index_width is not None:
                 self.index_label.setFixedWidth(index_width)
             self._layout.addWidget(self.index_label)

--- a/src/napari_metadata/widgets/_dict_viewer.py
+++ b/src/napari_metadata/widgets/_dict_viewer.py
@@ -84,12 +84,14 @@ class MetadataDictViewer(QWidget):
         if isinstance(value, dict):
             key_item = QTreeWidgetItem(parent, ['', ''])
             self._set_key_widget(key_item, key, index, index_width)
+            self._set_value_type_widget(key_item, 'dict')
             self.fill_tree(value, key_item)
-        elif isinstance(value, list):
+        elif isinstance(value, (list, tuple)):
             key_item = QTreeWidgetItem(parent, ['', ''])
             self._set_key_widget(key_item, key, index, index_width)
-            for i, val in enumerate(value):
-                self.fill_tree({str(i): val}, key_item)
+            type_name = 'list' if isinstance(value, list) else 'tuple'
+            self._set_value_type_widget(key_item, type_name)
+            self._fill_sequence_items(value, key_item, index_width)
         else:
             value_item = QTreeWidgetItem(parent, ['', ''])
             self._set_key_widget(value_item, key, index, index_width)
@@ -103,14 +105,65 @@ class MetadataDictViewer(QWidget):
     def _set_key_widget(
         self,
         item: QTreeWidgetItem,
-        key: str,
+        key: object,
         index: int | None = None,
         index_width: int | None = None,
     ) -> None:
         key_widget = KeyWidget(
-            str(key), index=index, index_width=index_width, parent=self
+            key, index=index, index_width=index_width, parent=self
         )
         self.tree.setItemWidget(item, 0, key_widget)
+        self._update_item_height(item)
+
+    def _set_index_key_widget(
+        self,
+        item: QTreeWidgetItem,
+        index: int,
+        index_width: int | None = None,
+    ) -> None:
+        label = QLabel(f'[{index}]', self)
+        label.setAlignment(
+            Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
+        )
+        if index_width is not None:
+            label.setMinimumWidth(index_width)
+        label.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
+        )
+        label.setContentsMargins(0, 0, 3, 0)
+        self.tree.setItemWidget(item, 0, label)
+        self._update_item_height(item)
+
+    def _fill_sequence_items(
+        self,
+        values: list | tuple,
+        parent: QTreeWidgetItem,
+        index_width: int | None,
+    ) -> None:
+        for i, val in enumerate(values):
+            index_item = QTreeWidgetItem(parent, ['', ''])
+            self._set_index_key_widget(index_item, i, index_width)
+            if isinstance(val, dict):
+                self._set_value_type_widget(index_item, 'dict')
+                self.fill_tree(val, index_item)
+            elif isinstance(val, (list, tuple)):
+                nested_type = 'list' if isinstance(val, list) else 'tuple'
+                self._set_value_type_widget(index_item, nested_type)
+                self._fill_sequence_items(val, index_item, index_width)
+            else:
+                value_widget = ValueWidget(val, self)
+                self.tree.setItemWidget(index_item, 1, value_widget)
+                self._update_item_height(index_item)
+
+    def _set_value_type_widget(
+        self, item: QTreeWidgetItem, type_name: str
+    ) -> None:
+        value_label = QLabel(type_name, self)
+        value_label.setStyleSheet('color: gray; font-style: italic;')
+        value_label.setAlignment(
+            Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
+        )
+        self.tree.setItemWidget(item, 1, value_label)
         self._update_item_height(item)
 
     def _set_item_selected(
@@ -152,13 +205,16 @@ class KeyWidget(QWidget):
 
     def __init__(
         self,
-        key: str,
+        key: object,
         index: int | None = None,
         index_width: int | None = None,
         parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent=parent)
-        self._original_key = key
+        self._original_key = str(key)
+        self._is_editable = isinstance(key, str) or (
+            isinstance(key, (int, float)) and not isinstance(key, bool)
+        )
         self._layout = QHBoxLayout(self)
         self._layout.setContentsMargins(0, 0, 8, 0)
         self._layout.setSpacing(4)
@@ -169,22 +225,42 @@ class KeyWidget(QWidget):
             self._layout.addWidget(self.index_label)
         elif index_width is not None:
             spacer = QLabel('', self)
-            spacer.setFixedWidth(index_width)
+            spacer.setFixedWidth(index_width + 5)
             self._layout.addWidget(spacer)
-        self.key_edit = QLineEdit(key, self)
-        self.key_edit.setReadOnly(True)
+        if self._is_editable:
+            self.key_edit = QLineEdit(self._original_key, self)
+            self.key_edit.setReadOnly(True)
+        else:
+            self.key_label = QLabel(self._original_key, self)
         self.edit_button = QPushButton('Edit', self)
-        self.edit_button.setCheckable(True)
+        self.edit_button.setSizePolicy(
+            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
+        )
+        self.edit_button.setCheckable(self._is_editable)
         self.delete_button = QPushButton('Delete', self)
-        self._apply_icon(self.edit_button, 'edit.svg', 'Edit', QSize(14, 14))
-        self._apply_icon(self.delete_button, 'delete.svg', 'Delete', QSize(18, 18))
+        if self._is_editable:
+            self._apply_icon(
+                self.edit_button, 'edit.svg', 'Edit', QSize(14, 14)
+            )
+        else:
+            self.edit_button.setEnabled(False)
+            self.edit_button.setText('NE')
+            self.edit_button.setToolTip('Non-editable data')
+            self.edit_button.setStyleSheet('color: gray; font-style: italic;')
+            self.edit_button.setFixedSize(QSize(26, 26))
+        self._apply_icon(
+            self.delete_button, 'delete.svg', 'Delete', QSize(18, 18)
+        )
         self._layout.addWidget(self.edit_button)
         self._layout.addWidget(self.delete_button)
-        self._layout.addWidget(self.key_edit)
-        self.key_edit.editingFinished.connect(self._on_editing_finished)
-        self.edit_button.toggled.connect(
-            lambda checked: self.key_edit.setReadOnly(not checked)
-        )
+        if self._is_editable:
+            self._layout.addWidget(self.key_edit)
+            self.key_edit.editingFinished.connect(self._on_editing_finished)
+            self.edit_button.toggled.connect(
+                lambda checked: self.key_edit.setReadOnly(not checked)
+            )
+        else:
+            self._layout.addWidget(self.key_label)
 
     def _on_editing_finished(self) -> None:
         new_key = self.key_edit.text()
@@ -268,7 +344,9 @@ class ValueWidget(QWidget):
         self.edit_button.setVisible(editable)
         self.delete_button = QPushButton('Delete', self)
         self._apply_icon(self.edit_button, 'edit.svg', 'Edit', QSize(14, 14))
-        self._apply_icon(self.delete_button, 'delete.svg', 'Delete', QSize(18, 18))
+        self._apply_icon(
+            self.delete_button, 'delete.svg', 'Delete', QSize(18, 18)
+        )
         self._layout.addWidget(self.edit_button)
         self._layout.addWidget(self.delete_button)
         if editable:
@@ -294,7 +372,9 @@ class ValueWidget(QWidget):
 
 def _load_icon(name: str) -> QIcon:
     try:
-        icon_path = resources.files('napari_metadata') / 'resources' / 'icons' / name
+        icon_path = (
+            resources.files('napari_metadata') / 'resources' / 'icons' / name
+        )
     except Exception:
         return QIcon()
     if not icon_path.is_file():

--- a/src/napari_metadata/widgets/_dict_viewer.py
+++ b/src/napari_metadata/widgets/_dict_viewer.py
@@ -4,9 +4,22 @@ Implement dictionary viewer widget
 
 from __future__ import annotations
 
+from importlib import resources
 from typing import TYPE_CHECKING
 
-from qtpy.QtWidgets import QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
+from qtpy.QtCore import Signal, QSize, Qt
+from qtpy.QtGui import QFontMetrics, QIcon
+from qtpy.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QSizePolicy,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
 
 from napari_metadata.layer_utils import get_layer_metadata_dict
 
@@ -29,6 +42,15 @@ class MetadataDictViewer(QWidget):
         self._layout.addWidget(self.tree)
         self.setLayout(self._layout)
         self.tree.setHeaderLabels(['Key', 'Value'])
+        self.tree.setStyleSheet(
+            'QTreeWidget::item { padding-top: 4px; padding-bottom: 4px; }'
+        )
+        self.setMinimumHeight(600)
+        self.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
+        )
+        self._selected_items: set[QTreeWidgetItem] = set()
+        self.tree.itemSelectionChanged.connect(self._on_item_selection_changed)
         self.set_data(data)
 
     def set_data(self, data: dict | None):
@@ -39,16 +61,242 @@ class MetadataDictViewer(QWidget):
         self.fill_tree(data, self.tree)
 
     def fill_tree(self, data: dict, parent: QTreeWidget | QTreeWidgetItem):
-        for key, value in data.items():
-            if isinstance(value, dict):
-                key_item = QTreeWidgetItem(parent, [key])
-                self.fill_tree(value, key_item)
-            elif isinstance(value, list):
-                key_item = QTreeWidgetItem(parent, [key])
-                for i, val in enumerate(value):
-                    self.fill_tree({str(i): val}, key_item)
-            else:
-                QTreeWidgetItem(parent, [key, str(value)])
+        is_root = parent is self.tree
+        if is_root:
+            index_width = self._get_index_label_width(len(data))
+            self._index_label_width = index_width
+            items = enumerate(data.items(), start=1)
+            for index, (key, value) in items:
+                self._fill_tree_item(parent, key, value, index, index_width)
+        else:
+            index_width = getattr(self, '_index_label_width', None)
+            for key, value in data.items():
+                self._fill_tree_item(parent, key, value, None, index_width)
+
+    def _fill_tree_item(
+        self,
+        parent: QTreeWidget | QTreeWidgetItem,
+        key: str,
+        value: object,
+        index: int | None,
+        index_width: int | None,
+    ) -> None:
+        if isinstance(value, dict):
+            key_item = QTreeWidgetItem(parent, ['', ''])
+            self._set_key_widget(key_item, key, index, index_width)
+            self.fill_tree(value, key_item)
+        elif isinstance(value, list):
+            key_item = QTreeWidgetItem(parent, ['', ''])
+            self._set_key_widget(key_item, key, index, index_width)
+            for i, val in enumerate(value):
+                self.fill_tree({str(i): val}, key_item)
+        else:
+            value_item = QTreeWidgetItem(parent, ['', ''])
+            self._set_key_widget(value_item, key, index, index_width)
+            value_widget = ValueWidget(value, self)
+            self.tree.setItemWidget(value_item, 1, value_widget)
+            self._update_item_height(value_item)
 
     def load_layer_dict(self) -> None:
         self.set_data(get_layer_metadata_dict(self._napari_viewer))
+
+    def _set_key_widget(
+        self,
+        item: QTreeWidgetItem,
+        key: str,
+        index: int | None = None,
+        index_width: int | None = None,
+    ) -> None:
+        key_widget = KeyWidget(
+            str(key), index=index, index_width=index_width, parent=self
+        )
+        self.tree.setItemWidget(item, 0, key_widget)
+        self._update_item_height(item)
+
+    def _set_item_selected(
+        self, item: QTreeWidgetItem, selected: bool
+    ) -> None:
+        value_widget = self.tree.itemWidget(item, 1)
+        if isinstance(value_widget, ValueWidget):
+            value_widget.set_selected(selected)
+
+    def _on_item_selection_changed(self) -> None:
+        current = set(self.tree.selectedItems())
+        for item in self._selected_items - current:
+            self._set_item_selected(item, False)
+        for item in current - self._selected_items:
+            self._set_item_selected(item, True)
+        self._selected_items = current
+
+    def _update_item_height(self, item: QTreeWidgetItem) -> None:
+        heights = []
+        for column in (0, 1):
+            widget = self.tree.itemWidget(item, column)
+            if widget is not None:
+                heights.append(widget.sizeHint().height())
+        if not heights:
+            return
+        height = max(heights) + 8
+        item.setSizeHint(0, QSize(0, height))
+        item.setSizeHint(1, QSize(0, height))
+
+    def _get_index_label_width(self, count: int) -> int:
+        digits = max(1, len(str(count)))
+        sample = '0' * digits
+        metrics = QFontMetrics(self.font())
+        return max(metrics.horizontalAdvance(sample) + 10, 24)
+
+
+class KeyWidget(QWidget):
+    key_changed = Signal(str, str)
+
+    def __init__(
+        self,
+        key: str,
+        index: int | None = None,
+        index_width: int | None = None,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent=parent)
+        self._original_key = key
+        self._layout = QHBoxLayout(self)
+        self._layout.setContentsMargins(0, 0, 8, 0)
+        self._layout.setSpacing(4)
+        if index is not None:
+            self.index_label = QLabel(str(index), self)
+            if index_width is not None:
+                self.index_label.setFixedWidth(index_width)
+            self._layout.addWidget(self.index_label)
+        elif index_width is not None:
+            spacer = QLabel('', self)
+            spacer.setFixedWidth(index_width)
+            self._layout.addWidget(spacer)
+        self.key_edit = QLineEdit(key, self)
+        self.key_edit.setReadOnly(True)
+        self.edit_button = QPushButton('Edit', self)
+        self.edit_button.setCheckable(True)
+        self.delete_button = QPushButton('Delete', self)
+        self._apply_icon(self.edit_button, 'edit.svg', 'Edit', QSize(14, 14))
+        self._apply_icon(self.delete_button, 'delete.svg', 'Delete', QSize(18, 18))
+        self._layout.addWidget(self.edit_button)
+        self._layout.addWidget(self.delete_button)
+        self._layout.addWidget(self.key_edit)
+        self.key_edit.editingFinished.connect(self._on_editing_finished)
+        self.edit_button.toggled.connect(
+            lambda checked: self.key_edit.setReadOnly(not checked)
+        )
+
+    def _on_editing_finished(self) -> None:
+        new_key = self.key_edit.text()
+        if new_key == self._original_key:
+            return
+        old_key = self._original_key
+        self._original_key = new_key
+        self.key_changed.emit(old_key, new_key)
+
+    def _apply_icon(
+        self,
+        button: QPushButton,
+        icon_name: str,
+        tooltip: str,
+        icon_size: QSize,
+    ) -> None:
+        icon = _load_icon(icon_name)
+        if not icon.isNull():
+            button.setIcon(icon)
+            button.setText('')
+            button.setToolTip(tooltip)
+            button.setIconSize(icon_size)
+        button.setFixedSize(QSize(26, 26))
+
+
+class ValueWidget(QWidget):
+    def __init__(self, value: object, parent: QWidget | None = None) -> None:
+        super().__init__(parent=parent)
+        self._layout = QHBoxLayout(self)
+        self._layout.setContentsMargins(8, 0, 0, 0)
+        self._layout.setSpacing(4)
+        self._editable = False
+
+        if isinstance(value, str):
+            self.value_edit = QLineEdit(value, self)
+            self.value_edit.setReadOnly(True)
+            self.type_label = QLabel('string', self)
+            self.type_label.setStyleSheet('color: #e68c2c;')
+            self.type_label.setAlignment(Qt.AlignmentFlag.AlignHCenter)
+            self.type_label.setFixedWidth(56)
+            self._layout.addWidget(self.value_edit)
+            self._layout.addWidget(self.type_label)
+            self._add_controls(editable=True)
+            self._editable = True
+        elif isinstance(value, (int, float)) and not isinstance(value, bool):
+            self.value_edit = QLineEdit(str(value), self)
+            self.value_edit.setReadOnly(True)
+            self.type_label = QLabel('number', self)
+            self.type_label.setStyleSheet('color: #4091ed;')
+            self.type_label.setAlignment(Qt.AlignmentFlag.AlignHCenter)
+            self.type_label.setFixedWidth(56)
+            self._layout.addWidget(self.value_edit)
+            self._layout.addWidget(self.type_label)
+            self._add_controls(editable=True)
+            self._editable = True
+        else:
+            self.value_label = QLabel(str(value), self)
+            self.type_label = QLabel('Non-editable', self)
+            self.type_label.setAlignment(Qt.AlignmentFlag.AlignRight)
+            self.type_label.setSizePolicy(
+                QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Expanding
+            )
+            self.type_label.setStyleSheet('color: gray; font-style: italic;')
+            self._layout.addWidget(self.value_label)
+            self._layout.addWidget(
+                self.type_label, alignment=Qt.AlignmentFlag.AlignVCenter
+            )
+            self._add_controls(editable=False)
+
+    def set_selected(self, selected: bool) -> None:
+        if self._editable:
+            return
+        if selected:
+            self.type_label.setStyleSheet('color: black; font-style: italic;')
+        else:
+            self.type_label.setStyleSheet('color: gray; font-style: italic;')
+
+    def _add_controls(self, editable: bool) -> None:
+        self.edit_button = QPushButton('Edit', self)
+        self.edit_button.setCheckable(True)
+        self.edit_button.setVisible(editable)
+        self.delete_button = QPushButton('Delete', self)
+        self._apply_icon(self.edit_button, 'edit.svg', 'Edit', QSize(14, 14))
+        self._apply_icon(self.delete_button, 'delete.svg', 'Delete', QSize(18, 18))
+        self._layout.addWidget(self.edit_button)
+        self._layout.addWidget(self.delete_button)
+        if editable:
+            self.edit_button.toggled.connect(
+                lambda checked: self.value_edit.setReadOnly(not checked)
+            )
+
+    def _apply_icon(
+        self,
+        button: QPushButton,
+        icon_name: str,
+        tooltip: str,
+        icon_size: QSize,
+    ) -> None:
+        icon = _load_icon(icon_name)
+        if not icon.isNull():
+            button.setIcon(icon)
+            button.setText('')
+            button.setToolTip(tooltip)
+            button.setIconSize(icon_size)
+        button.setFixedSize(QSize(26, 26))
+
+
+def _load_icon(name: str) -> QIcon:
+    try:
+        icon_path = resources.files('napari_metadata') / 'resources' / 'icons' / name
+    except Exception:
+        return QIcon()
+    if not icon_path.is_file():
+        return QIcon()
+    return QIcon(str(icon_path))

--- a/src/napari_metadata/widgets/_dict_viewer.py
+++ b/src/napari_metadata/widgets/_dict_viewer.py
@@ -52,6 +52,8 @@ class MetadataDictViewer(QWidget):
             QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
         )
         self._selected_items: set[QTreeWidgetItem] = set()
+        self._editing_entry = False
+        self._editing_widget: KeyWidget | ValueWidget | None = None
         self.tree.itemSelectionChanged.connect(self._on_item_selection_changed)
         self.set_data(data)
 
@@ -89,19 +91,36 @@ class MetadataDictViewer(QWidget):
         if isinstance(value, dict):
             key_item = QTreeWidgetItem(parent, ['', ''])
             self._set_key_widget(key_item, key, index, index_width)
+            key_item.setData(0, Qt.ItemDataRole.UserRole, {'key': key})
+            key_item.setData(
+                1,
+                Qt.ItemDataRole.UserRole,
+                {'type': 'dictionary', 'value': value},
+            )
             self._set_value_type_widget(key_item, 'dict')
             self.fill_tree(value, key_item)
         elif isinstance(value, (list, tuple)):
             key_item = QTreeWidgetItem(parent, ['', ''])
             self._set_key_widget(key_item, key, index, index_width)
+            key_item.setData(0, Qt.ItemDataRole.UserRole, {'key': key})
+            key_item.setData(
+                1,
+                Qt.ItemDataRole.UserRole,
+                {
+                    'type': 'list' if isinstance(value, list) else 'tuple',
+                    'value': value,
+                },
+            )
             type_name = 'list' if isinstance(value, list) else 'tuple'
             self._set_value_type_widget(key_item, type_name)
             self._fill_sequence_items(value, key_item, index_width, type_name)
         else:
             value_item = QTreeWidgetItem(parent, ['', ''])
             self._set_key_widget(value_item, key, index, index_width)
+            value_item.setData(0, Qt.ItemDataRole.UserRole, {'key': key})
             value_widget = ValueWidget(value, self)
             self.tree.setItemWidget(value_item, 1, value_widget)
+            self._set_value_item_data(value_item, value)
             self._update_item_height(value_item)
 
     def load_layer_dict(self) -> None:
@@ -129,7 +148,7 @@ class MetadataDictViewer(QWidget):
     ) -> None:
         container = QWidget(self)
         layout = QHBoxLayout(container)
-        layout.setContentsMargins(0, 0, 8, 0)
+        layout.setContentsMargins(0, 0, 16, 0)
         layout.setSpacing(4)
         label = QLabel(f'[{index}]', container)
         label.setAlignment(
@@ -146,6 +165,7 @@ class MetadataDictViewer(QWidget):
             QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
         )
         self.tree.setItemWidget(item, 0, container)
+        item.setData(0, Qt.ItemDataRole.UserRole, {'index': index})
         self._update_item_height(item)
 
     def _set_add_row_widget(
@@ -156,7 +176,7 @@ class MetadataDictViewer(QWidget):
     ) -> None:
         container = QWidget(self)
         layout = QHBoxLayout(container)
-        layout.setContentsMargins(0, 0, 8, 0)
+        layout.setContentsMargins(0, 0, 16, 0)
         layout.setSpacing(4)
         add_button = QPushButton('Add', container)
         icon = _load_icon('add.svg')
@@ -175,14 +195,21 @@ class MetadataDictViewer(QWidget):
             QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
         )
         self.tree.setItemWidget(item, 0, container)
-        combo_container = self._create_add_value_widget()
+        item.setData(0, Qt.ItemDataRole.UserRole, {'add_row': True})
+        combo_container, value_widgets = self._create_add_value_widget()
         self.tree.setItemWidget(item, 1, combo_container)
+        item.setData(
+            1, Qt.ItemDataRole.UserRole, {'add_row': True, **value_widgets}
+        )
+        add_button.clicked.connect(
+            lambda: self._add_sequence_entry(item, sequence_type)
+        )
         self._update_item_height(item)
 
-    def _create_add_value_widget(self) -> QWidget:
+    def _create_add_value_widget(self) -> tuple[QWidget, dict]:
         container = QWidget(self)
         layout = QHBoxLayout(container)
-        layout.setContentsMargins(8, 0, 0, 0)
+        layout.setContentsMargins(16, 0, 0, 0)
         layout.setSpacing(4)
         combo_width = 116
         value_edit = QLineEdit(container)
@@ -193,7 +220,7 @@ class MetadataDictViewer(QWidget):
         )
         combo = QComboBox(container)
         combo.addItems(
-            ['number', 'string', 'tuple', 'list', 'dictionary', 'none']
+            ['number', 'string', 'bool', 'tuple', 'list', 'dictionary', 'none']
         )
         combo.setFixedWidth(combo_width)
         layout.addWidget(value_edit)
@@ -203,26 +230,50 @@ class MetadataDictViewer(QWidget):
             QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
         )
 
+        bool_combo = QComboBox(container)
+        bool_combo.addItems(['True', 'False'])
+        bool_combo.setVisible(False)
+        bool_combo.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
+        )
+        layout.insertWidget(1, bool_combo)
+
         def update_value_widget(selection: str) -> None:
             if selection in ('number', 'string'):
                 value_edit.setVisible(True)
+                bool_combo.setVisible(False)
                 type_label.setVisible(False)
                 if value_edit.text() == 'None':
                     value_edit.setText('')
                 return
+            if selection == 'bool':
+                value_edit.setVisible(False)
+                bool_combo.setVisible(True)
+                type_label.setVisible(False)
+                return
             if selection == 'none':
                 value_edit.setVisible(False)
+                bool_combo.setVisible(False)
                 type_label.setText('NA')
                 type_label.setVisible(True)
                 return
             value_edit.setVisible(False)
+            bool_combo.setVisible(False)
             label_text = 'dict' if selection == 'dictionary' else selection
             type_label.setText(label_text)
             type_label.setVisible(True)
 
         combo.currentTextChanged.connect(update_value_widget)
         update_value_widget(combo.currentText())
-        return container
+        return (
+            container,
+            {
+                'value_edit': value_edit,
+                'type_label': type_label,
+                'type_combo': combo,
+                'bool_combo': bool_combo,
+            },
+        )
 
     def _add_dict_add_row(
         self,
@@ -231,6 +282,7 @@ class MetadataDictViewer(QWidget):
         is_root: bool,
     ) -> None:
         add_item = QTreeWidgetItem(parent, ['', ''])
+        add_item.setData(0, Qt.ItemDataRole.UserRole, {'add_row': True})
         self._set_dict_add_row_widget(add_item, index_width, is_root)
 
     def _set_dict_add_row_widget(
@@ -238,7 +290,7 @@ class MetadataDictViewer(QWidget):
     ) -> None:
         key_container = QWidget(self)
         key_layout = QHBoxLayout(key_container)
-        key_layout.setContentsMargins(0, 0, 8, 0)
+        key_layout.setContentsMargins(0, 0, 16, 0)
         key_layout.setSpacing(4)
         add_button = QPushButton('Add', key_container)
         icon = _load_icon('add.svg')
@@ -262,8 +314,19 @@ class MetadataDictViewer(QWidget):
         )
         self.tree.setItemWidget(item, 0, key_container)
 
-        value_container = self._create_add_value_widget()
+        value_container, value_widgets = self._create_add_value_widget()
         self.tree.setItemWidget(item, 1, value_container)
+        item.setData(
+            0,
+            Qt.ItemDataRole.UserRole,
+            {
+                'add_row': True,
+                'key_edit': key_edit,
+                'key_combo': key_combo,
+            },
+        )
+        item.setData(1, Qt.ItemDataRole.UserRole, {'add_row': True, **value_widgets})
+        add_button.clicked.connect(lambda: self._add_dict_entry(item))
         self._update_item_height(item)
 
     def _fill_sequence_items(
@@ -280,16 +343,19 @@ class MetadataDictViewer(QWidget):
             )
             if isinstance(val, dict):
                 self._set_value_type_widget(index_item, 'dict')
+                self._set_value_item_data(index_item, val)
                 self.fill_tree(val, index_item)
             elif isinstance(val, (list, tuple)):
                 nested_type = 'list' if isinstance(val, list) else 'tuple'
                 self._set_value_type_widget(index_item, nested_type)
+                self._set_value_item_data(index_item, val)
                 self._fill_sequence_items(
                     val, index_item, index_width, nested_type
                 )
             else:
                 value_widget = ValueWidget(val, self)
                 self.tree.setItemWidget(index_item, 1, value_widget)
+                self._set_value_item_data(index_item, val)
                 self._update_item_height(index_item)
         add_item = QTreeWidgetItem(parent, ['', ''])
         self._set_add_row_widget(add_item, sequence_type, index_width)
@@ -297,20 +363,13 @@ class MetadataDictViewer(QWidget):
     def _set_value_type_widget(
         self, item: QTreeWidgetItem, type_name: str
     ) -> None:
-        value_label = QLabel(type_name, self)
-        value_label.setStyleSheet('color: gray; font-style: italic;')
-        value_label.setAlignment(
-            Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
+        value_widget = ValueWidget(None, self, container_type=type_name)
+        self.tree.setItemWidget(item, 1, value_widget)
+        item.setData(
+            1,
+            Qt.ItemDataRole.UserRole,
+            {'type': 'dictionary' if type_name == 'dict' else type_name},
         )
-        container = QWidget(self)
-        layout = QHBoxLayout(container)
-        layout.setContentsMargins(8, 0, 0, 0)
-        layout.setSpacing(0)
-        layout.addWidget(value_label)
-        container.setSizePolicy(
-            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
-        )
-        self.tree.setItemWidget(item, 1, container)
         self._update_item_height(item)
 
     def _set_item_selected(
@@ -322,6 +381,19 @@ class MetadataDictViewer(QWidget):
         value_widget = self.tree.itemWidget(item, 1)
         if isinstance(value_widget, ValueWidget):
             value_widget.set_selected(selected)
+
+    def _request_edit(self, widget: KeyWidget | ValueWidget) -> None:
+        if self._editing_widget is widget:
+            return
+        if self._editing_widget is not None:
+            self._editing_widget.discard_edit()
+        self._editing_widget = widget
+        self._editing_entry = True
+
+    def _end_edit(self, widget: KeyWidget | ValueWidget) -> None:
+        if self._editing_widget is widget:
+            self._editing_widget = None
+            self._editing_entry = False
 
     def _on_item_selection_changed(self) -> None:
         current = set(self.tree.selectedItems())
@@ -351,6 +423,239 @@ class MetadataDictViewer(QWidget):
         metrics = QFontMetrics(self.font())
         return max(metrics.horizontalAdvance(sample) + 10, 24)
 
+    def _set_value_item_data(
+        self, item: QTreeWidgetItem, value: object
+    ) -> None:
+        item.setData(
+            1,
+            Qt.ItemDataRole.UserRole,
+            {'type': self._infer_value_type(value), 'value': value},
+        )
+
+    def _get_add_value_spec(self, item: QTreeWidgetItem) -> tuple[str, object]:
+        data = item.data(1, Qt.ItemDataRole.UserRole) or {}
+        if not isinstance(data, dict):
+            return 'string', ''
+        type_combo = data.get('type_combo')
+        value_edit = data.get('value_edit')
+        bool_combo = data.get('bool_combo')
+        if type_combo is None:
+            return 'string', ''
+        selected_type = type_combo.currentText()
+        if selected_type == 'number':
+            number_value = _parse_number_text(value_edit.text())
+            if isinstance(number_value, str):
+                return 'invalid', None
+            return 'number', number_value
+        if selected_type == 'string':
+            return 'string', value_edit.text()
+        if selected_type == 'bool':
+            value = True if bool_combo.currentText() == 'True' else False
+            return 'bool', value
+        if selected_type == 'none':
+            return 'none', None
+        if selected_type == 'dictionary':
+            return 'dictionary', {}
+        if selected_type == 'tuple':
+            return 'tuple', ()
+        if selected_type == 'list':
+            return 'list', []
+        return 'string', value_edit.text()
+
+    def _insert_child(
+        self,
+        parent: QTreeWidget | QTreeWidgetItem,
+        index: int,
+        item: QTreeWidgetItem,
+    ) -> None:
+        if isinstance(parent, QTreeWidget):
+            parent.insertTopLevelItem(index, item)
+        else:
+            parent.insertChild(index, item)
+
+    def _add_sequence_entry(
+        self, add_item: QTreeWidgetItem, sequence_type: str
+    ) -> None:
+        parent = add_item.parent()
+        if parent is None:
+            return
+        index_width = getattr(self, '_index_label_width', None)
+        insert_index = parent.indexOfChild(add_item)
+        entry_index = 0
+        for i in range(parent.childCount()):
+            child = parent.child(i)
+            if self._is_add_row(child):
+                continue
+            entry_index += 1
+        value_type, value = self._get_add_value_spec(add_item)
+        if value_type == 'invalid':
+            return
+        new_item = QTreeWidgetItem(['', ''])
+        self._insert_child(parent, insert_index, new_item)
+        self._set_index_key_widget(new_item, entry_index, sequence_type, index_width)
+        if value_type == 'dictionary':
+            self._set_value_type_widget(new_item, 'dict')
+            self._set_value_item_data(new_item, value)
+            self.fill_tree(value, new_item)
+        elif value_type == 'list':
+            self._set_value_type_widget(new_item, 'list')
+            self._set_value_item_data(new_item, value)
+            self._fill_sequence_items(value, new_item, index_width, 'list')
+        elif value_type == 'tuple':
+            self._set_value_type_widget(new_item, 'tuple')
+            self._set_value_item_data(new_item, value)
+            self._fill_sequence_items(value, new_item, index_width, 'tuple')
+        else:
+            value_widget = ValueWidget(value, self)
+            self.tree.setItemWidget(new_item, 1, value_widget)
+            self._set_value_item_data(new_item, value)
+            self._update_item_height(new_item)
+        self._recreate_dictionary()
+
+    def _add_dict_entry(self, add_item: QTreeWidgetItem) -> None:
+        parent = add_item.parent() or self.tree
+        data = add_item.data(0, Qt.ItemDataRole.UserRole) or {}
+        if not isinstance(data, dict):
+            return
+        key_edit = data.get('key_edit')
+        key_combo = data.get('key_combo')
+        if key_edit is None or key_combo is None:
+            return
+        key_text = key_edit.text()
+        if key_text == '':
+            return
+        if key_combo.currentText() == 'number':
+            key_value = _parse_number_text(key_text)
+            if isinstance(key_value, str):
+                return
+        else:
+            key_value = key_text
+        index_width = getattr(self, '_index_label_width', None)
+        insert_index = (
+            parent.indexOfChild(add_item)
+            if isinstance(parent, QTreeWidgetItem)
+            else self.tree.indexOfTopLevelItem(add_item)
+        )
+        value_type, value = self._get_add_value_spec(add_item)
+        if value_type == 'invalid':
+            return
+        new_item = QTreeWidgetItem(['', ''])
+        if isinstance(parent, QTreeWidget):
+            parent.insertTopLevelItem(insert_index, new_item)
+        else:
+            parent.insertChild(insert_index, new_item)
+        self._set_key_widget(new_item, key_value, insert_index, index_width)
+        new_item.setData(0, Qt.ItemDataRole.UserRole, {'key': key_value})
+        if value_type == 'dictionary':
+            self._set_value_type_widget(new_item, 'dict')
+            self._set_value_item_data(new_item, value)
+            self.fill_tree(value, new_item)
+        elif value_type == 'list':
+            self._set_value_type_widget(new_item, 'list')
+            self._set_value_item_data(new_item, value)
+            self._fill_sequence_items(value, new_item, index_width, 'list')
+        elif value_type == 'tuple':
+            self._set_value_type_widget(new_item, 'tuple')
+            self._set_value_item_data(new_item, value)
+            self._fill_sequence_items(value, new_item, index_width, 'tuple')
+        else:
+            value_widget = ValueWidget(value, self)
+            self.tree.setItemWidget(new_item, 1, value_widget)
+            self._set_value_item_data(new_item, value)
+            self._update_item_height(new_item)
+        self._recreate_dictionary()
+
+    def _infer_value_type(self, value: object) -> str:
+        if value is None:
+            return 'none'
+        if isinstance(value, bool):
+            return 'bool'
+        if isinstance(value, str):
+            return 'string'
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return 'number'
+        if isinstance(value, dict):
+            return 'dictionary'
+        if isinstance(value, list):
+            return 'list'
+        if isinstance(value, tuple):
+            return 'tuple'
+        return 'other'
+
+    def _is_add_row(self, item: QTreeWidgetItem) -> bool:
+        data = item.data(0, Qt.ItemDataRole.UserRole)
+        return isinstance(data, dict) and data.get('add_row', False)
+
+    def _recreate_dictionary(self) -> None:
+        def parse_key(item: QTreeWidgetItem) -> object:
+            key_widget = self.tree.itemWidget(item, 0)
+            data = item.data(0, Qt.ItemDataRole.UserRole) or {}
+            if not isinstance(key_widget, KeyWidget):
+                return data.get('key')
+            if not key_widget.was_edited():
+                if hasattr(key_widget, 'key_edit'):
+                    return data.get('key', key_widget.key_edit.text())
+                return data.get('key')
+            if hasattr(key_widget, 'key_edit'):
+                key_text = key_widget.key_edit.text()
+            else:
+                key_text = key_widget.key_label.text()
+            key_type = key_widget.type_label.text().lower()
+            if key_type == 'number':
+                return _parse_number_text(key_text)
+            if key_type == 'non-editable':
+                return data.get('key', key_text)
+            return key_text
+
+        def parse_value(item: QTreeWidgetItem) -> object:
+            value_widget = self.tree.itemWidget(item, 1)
+            if isinstance(value_widget, ValueWidget):
+                value_type = value_widget.get_type()
+                if value_type in ('dictionary', 'list', 'tuple'):
+                    return parse_container(item, value_type)
+                if not value_widget.was_edited():
+                    data = item.data(1, Qt.ItemDataRole.UserRole) or {}
+                    if isinstance(data, dict) and 'value' in data:
+                        return data['value']
+                if value_type == 'other':
+                    data = item.data(1, Qt.ItemDataRole.UserRole) or {}
+                    if isinstance(data, dict) and 'value' in data:
+                        return data['value']
+                return value_widget.get_value()
+            data = item.data(1, Qt.ItemDataRole.UserRole) or {}
+            if isinstance(data, dict) and 'value' in data:
+                return data['value']
+            return None
+
+        def parse_container(
+            item: QTreeWidgetItem, container_type: str
+        ) -> object:
+            if container_type == 'dictionary':
+                result: dict = {}
+                for i in range(item.childCount()):
+                    child = item.child(i)
+                    if self._is_add_row(child):
+                        continue
+                    key = parse_key(child)
+                    result[key] = parse_value(child)
+                return result
+            values = []
+            for i in range(item.childCount()):
+                child = item.child(i)
+                if self._is_add_row(child):
+                    continue
+                values.append(parse_value(child))
+            return tuple(values) if container_type == 'tuple' else values
+
+        result: dict = {}
+        for i in range(self.tree.topLevelItemCount()):
+            item = self.tree.topLevelItem(i)
+            if self._is_add_row(item):
+                continue
+            key = parse_key(item)
+            result[key] = parse_value(item)
+        print(result)
+
 
 class KeyWidget(QWidget):
     key_changed = Signal(str, str)
@@ -363,13 +668,19 @@ class KeyWidget(QWidget):
         parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent=parent)
+        self._viewer = parent if isinstance(parent, MetadataDictViewer) else None
         self._original_key = str(key)
         self._is_editable = isinstance(key, str) or (
             isinstance(key, (int, float)) and not isinstance(key, bool)
         )
         self._type_label_color: str | None = None
+        self._edit_icon = _load_icon('edit.svg')
+        self._confirm_icon = _load_icon('confirm.svg')
+        self._discarding = False
+        self._edited = False
+        self._bool_combo: QComboBox | None = None
         self._layout = QHBoxLayout(self)
-        self._layout.setContentsMargins(0, 0, 8, 0)
+        self._layout.setContentsMargins(0, 0, 16, 0)
         self._layout.setSpacing(4)
         if index is not None:
             self.index_label = QLabel(f'[{index}]', self)
@@ -380,23 +691,22 @@ class KeyWidget(QWidget):
             spacer = QLabel('', self)
             spacer.setFixedWidth(index_width)
             self._layout.addWidget(spacer)
-        if self._is_editable:
-            self.key_edit = QLineEdit(self._original_key, self)
-            self.key_edit.setReadOnly(True)
-            if isinstance(key, str):
-                type_text = 'string'
-                self._type_label_color = '#e68c2c'
-            else:
-                type_text = 'number'
-                self._type_label_color = '#4091ed'
-            self._original_type = type_text
+        self.key_edit = QLineEdit(self._original_key, self)
+        self.key_edit.setReadOnly(True)
+        if isinstance(key, str):
+            type_text = 'string'
+            self._type_label_color = '#e68c2c'
+        elif isinstance(key, (int, float)) and not isinstance(key, bool):
+            type_text = 'number'
+            self._type_label_color = '#4091ed'
         else:
-            self.key_label = QLabel(self._original_key, self)
-            type_text = 'Non-editable'
+            type_text = 'NE'
+        self._original_type = type_text
         self.type_combo = QComboBox(self)
         self.type_combo.addItems(['number', 'string'])
         self.type_combo.setVisible(False)
         self.delete_button = QPushButton('Delete', self)
+        self.delete_button.setCheckable(True)
         self.type_label = QLabel(type_text, self)
         if self._is_editable and self._type_label_color is not None:
             self.type_label.setStyleSheet(f'color: {self._type_label_color};')
@@ -405,41 +715,73 @@ class KeyWidget(QWidget):
         else:
             self.type_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
             self.type_label.setStyleSheet('color: gray; font-style: italic;')
-            self.type_label.setFixedWidth(86)
-        if self._is_editable:
-            self.edit_button = QPushButton('Edit', self)
-            self.edit_button.setSizePolicy(
-                QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
-            )
-            self.edit_button.setCheckable(True)
-            self._apply_icon(
-                self.edit_button, 'edit.svg', 'Edit', QSize(14, 14)
-            )
-        if self._is_editable:
-            pass
+            self.type_label.setFixedWidth(56)
+        self.edit_button = QPushButton('Edit', self)
+        self.edit_button.setSizePolicy(
+            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
+        )
+        self.edit_button.setCheckable(True)
+        self._apply_icon(self.edit_button, 'edit.svg', 'Edit', QSize(14, 14))
         self._apply_icon(
             self.delete_button, 'delete.svg', 'Delete', QSize(18, 18)
         )
-        if self._is_editable:
-            self._layout.addWidget(self.key_edit)
-            self.key_edit.editingFinished.connect(self._on_editing_finished)
-            self.edit_button.toggled.connect(self._on_edit_toggled)
-        else:
-            self._layout.addWidget(self.key_label)
+        self._layout.addWidget(self.key_edit)
+        self.edit_button.toggled.connect(self._on_edit_toggled)
         self._layout.addWidget(self.type_label)
         self._layout.addWidget(self.type_combo)
-        if self._is_editable:
-            self._layout.addWidget(self.edit_button)
+        self._layout.addWidget(self.edit_button)
         self._layout.addWidget(self.delete_button)
+        self.delete_button.clicked.connect(self._on_cancel_clicked)
 
     def _on_edit_toggled(self, checked: bool) -> None:
+        if checked and self._viewer is not None:
+            self._viewer._request_edit(self)
         self.key_edit.setReadOnly(not checked)
         self.type_label.setVisible(not checked)
         self.type_combo.setVisible(checked)
+        self.delete_button.setVisible(not checked)
         if checked:
-            self.type_combo.setCurrentText(self.type_label.text())
+            current_type = self._original_type
+            if current_type not in ('number', 'string'):
+                current_type = 'string'
+            self.type_combo.setCurrentText(current_type)
+            if not self._confirm_icon.isNull():
+                self.edit_button.setIcon(self._confirm_icon)
+            self._apply_icon(
+                self.delete_button, 'cancel.svg', 'Cancel', QSize(18, 18)
+            )
+            self.delete_button.setToolTip('Cancel edit')
+            self.delete_button.setChecked(True)
+            self.delete_button.setVisible(True)
+        else:
+            if not self._edit_icon.isNull():
+                self.edit_button.setIcon(self._edit_icon)
+            self._apply_icon(
+                self.delete_button, 'delete.svg', 'Delete', QSize(18, 18)
+            )
+            self.delete_button.setToolTip('Delete')
+            self.delete_button.setChecked(False)
+            if self._discarding:
+                self._discarding = False
+                self.key_edit.setText(self._original_key)
+                self.type_combo.setVisible(False)
+                self.type_label.setVisible(True)
+                return
+            self._commit_edit()
+            if self._viewer is not None:
+                self._viewer._end_edit(self)
 
-    def _on_editing_finished(self) -> None:
+    def _on_cancel_clicked(self) -> None:
+        if not self.edit_button.isChecked():
+            return
+        self.discard_edit()
+        self._apply_icon(
+            self.delete_button, 'delete.svg', 'Delete', QSize(18, 18)
+        )
+        if self._viewer is not None:
+            self._viewer._end_edit(self)
+
+    def _commit_edit(self) -> None:
         new_key = self.key_edit.text()
         selected_type = self.type_combo.currentText()
         if selected_type == 'number':
@@ -449,9 +791,7 @@ class KeyWidget(QWidget):
                 self.key_edit.setText(self._original_key)
                 self.type_combo.setCurrentText(self._original_type)
                 self._apply_type_selection(self._original_type)
-                self.edit_button.setChecked(False)
                 return
-        self.edit_button.setChecked(False)
         if new_key == self._original_key:
             self._apply_type_selection(selected_type)
             return
@@ -459,6 +799,10 @@ class KeyWidget(QWidget):
         self._original_key = new_key
         self.key_changed.emit(old_key, new_key)
         self._apply_type_selection(selected_type)
+        self._edited = True
+        if self._viewer is not None:
+            self._viewer._recreate_dictionary()
+            self._viewer._end_edit(self)
 
     def _apply_type_selection(self, selected_type: str | None = None) -> None:
         if selected_type is None:
@@ -472,6 +816,24 @@ class KeyWidget(QWidget):
         self.type_label.setStyleSheet(f'color: {self._type_label_color};')
         self.type_label.setVisible(True)
         self.type_combo.setVisible(False)
+
+    def discard_edit(self) -> None:
+        self._discarding = True
+        self.edit_button.setChecked(False)
+        self.key_edit.setText(self._original_key)
+        self.key_edit.setReadOnly(True)
+        self.type_combo.setVisible(False)
+        if self._original_type in ('string', 'number'):
+            self._apply_type_selection(self._original_type)
+        else:
+            self.type_label.setText('NE')
+            self.type_label.setStyleSheet('color: gray; font-style: italic;')
+            self.type_label.setVisible(True)
+        if not self._edit_icon.isNull():
+            self.edit_button.setIcon(self._edit_icon)
+
+    def was_edited(self) -> bool:
+        return self._edited
 
     def set_selected(self, selected: bool) -> None:
         if self._is_editable and self._type_label_color is not None:
@@ -504,15 +866,45 @@ class KeyWidget(QWidget):
 
 
 class ValueWidget(QWidget):
-    def __init__(self, value: object, parent: QWidget | None = None) -> None:
+    def __init__(
+        self,
+        value: object,
+        parent: QWidget | None = None,
+        container_type: str | None = None,
+    ) -> None:
         super().__init__(parent=parent)
+        self._viewer = parent if isinstance(parent, MetadataDictViewer) else None
         self._layout = QHBoxLayout(self)
-        self._layout.setContentsMargins(8, 0, 0, 0)
+        self._layout.setContentsMargins(16, 0, 0, 0)
         self._layout.setSpacing(4)
         self._editable = False
         self._type_label_color: str | None = None
+        self._original_value_text: str | None = None
+        self._original_type_text: str | None = None
+        self._edit_icon = _load_icon('edit.svg')
+        self._confirm_icon = _load_icon('confirm.svg')
+        self._discarding = False
+        self._edited = False
 
-        if isinstance(value, str):
+        if container_type is not None:
+            self.value_edit = QLineEdit('', self)
+            self.value_edit.setReadOnly(True)
+            self.type_label = QLabel('', self)
+            self.type_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            self.type_label.setFixedWidth(56)
+            self._layout.addWidget(self.value_edit)
+            self._layout.addWidget(self.type_label)
+            self._add_controls(editable=True)
+            self._editable = True
+            type_mapping = {
+                'dict': 'dictionary',
+                'list': 'list',
+                'tuple': 'tuple',
+            }
+            self._original_value_text = ''
+            self._original_type_text = type_mapping.get(container_type, 'list')
+            self._apply_value_display(self._original_type_text)
+        elif isinstance(value, str):
             self.value_edit = QLineEdit(value, self)
             self.value_edit.setReadOnly(True)
             self.type_label = QLabel('string', self)
@@ -524,6 +916,8 @@ class ValueWidget(QWidget):
             self._layout.addWidget(self.type_label)
             self._add_controls(editable=True)
             self._editable = True
+            self._original_value_text = value
+            self._original_type_text = 'string'
         elif isinstance(value, (int, float)) and not isinstance(value, bool):
             self.value_edit = QLineEdit(str(value), self)
             self.value_edit.setReadOnly(True)
@@ -536,6 +930,21 @@ class ValueWidget(QWidget):
             self._layout.addWidget(self.type_label)
             self._add_controls(editable=True)
             self._editable = True
+            self._original_value_text = str(value)
+            self._original_type_text = 'number'
+        elif isinstance(value, bool):
+            self.value_edit = QLineEdit(str(value), self)
+            self.value_edit.setReadOnly(True)
+            self.type_label = QLabel('bool', self)
+            self.type_label.setStyleSheet('color: #bf3be3;')
+            self.type_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            self.type_label.setFixedWidth(56)
+            self._layout.addWidget(self.value_edit)
+            self._layout.addWidget(self.type_label)
+            self._add_controls(editable=True)
+            self._editable = True
+            self._original_value_text = str(value)
+            self._original_type_text = 'bool'
         elif value is None:
             self.value_edit = QLineEdit('None', self)
             self.value_edit.setReadOnly(True)
@@ -546,20 +955,23 @@ class ValueWidget(QWidget):
             self._layout.addWidget(self.value_edit)
             self._layout.addWidget(self.type_label)
             self._add_controls(editable=True)
+            self.delete_button.setEnabled(False)
             self._editable = True
+            self._original_value_text = 'None'
+            self._original_type_text = 'none'
         else:
-            self.value_label = QLabel(str(value), self)
-            self.type_label = QLabel('Non-editable', self)
-            self.type_label.setAlignment(Qt.AlignmentFlag.AlignRight)
-            self.type_label.setSizePolicy(
-                QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Expanding
-            )
+            self.value_edit = QLineEdit(str(value), self)
+            self.value_edit.setReadOnly(True)
+            self.type_label = QLabel('NE', self)
+            self.type_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            self.type_label.setFixedWidth(56)
             self.type_label.setStyleSheet('color: gray; font-style: italic;')
-            self._layout.addWidget(self.value_label)
-            self._layout.addWidget(
-                self.type_label, alignment=Qt.AlignmentFlag.AlignVCenter
-            )
-            self._add_controls(editable=False)
+            self._layout.addWidget(self.value_edit)
+            self._layout.addWidget(self.type_label)
+            self._add_controls(editable=True)
+            self._editable = True
+            self._original_value_text = str(value)
+            self._original_type_text = 'other'
 
     def set_selected(self, selected: bool) -> None:
         if self._editable and self._type_label_color is not None:
@@ -572,14 +984,19 @@ class ValueWidget(QWidget):
             return
         if selected:
             self.type_label.setStyleSheet('color: black; font-style: italic;')
+            if hasattr(self, 'value_label') and self.value_label is not None:
+                self.value_label.setStyleSheet('color: black; font-style: italic;')
         else:
             self.type_label.setStyleSheet('color: gray; font-style: italic;')
+            if hasattr(self, 'value_label') and self.value_label is not None:
+                self.value_label.setStyleSheet('color: gray; font-style: italic;')
 
     def _add_controls(self, editable: bool) -> None:
         self.edit_button = QPushButton('Edit', self)
         self.edit_button.setCheckable(True)
         self.edit_button.setVisible(editable)
         self.delete_button = QPushButton('Delete', self)
+        self.delete_button.setCheckable(True)
         self._apply_icon(self.edit_button, 'edit.svg', 'Edit', QSize(14, 14))
         self._apply_icon(
             self.delete_button, 'delete.svg', 'Delete', QSize(18, 18)
@@ -589,52 +1006,281 @@ class ValueWidget(QWidget):
         if editable:
             self.type_combo = QComboBox(self)
             self.type_combo.addItems(
-                ['number', 'string', 'tuple', 'list', 'dictionary', 'none']
+                ['number', 'string', 'bool', 'tuple', 'list', 'dictionary', 'none']
+            )
+            self.type_combo.setSizeAdjustPolicy(
+                QComboBox.SizeAdjustPolicy.AdjustToContents
+            )
+            self.type_combo.setSizePolicy(
+                QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Preferred
+            )
+            self._bool_combo = QComboBox(self)
+            self._bool_combo.addItems(['True', 'False'])
+            self._bool_combo.setVisible(False)
+            self._bool_combo.setSizePolicy(
+                QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
             )
             self.type_combo.setVisible(False)
-            self._layout.insertWidget(1, self.type_combo)
+            self._layout.insertWidget(1, self._bool_combo)
+            self._layout.insertWidget(2, self.type_combo)
             self.edit_button.toggled.connect(self._on_edit_toggled)
+            self.type_combo.currentTextChanged.connect(
+                self._apply_value_type_selection
+            )
+        self.delete_button.clicked.connect(self._on_cancel_clicked)
 
     def _on_edit_toggled(self, checked: bool) -> None:
+        if checked and self._viewer is not None:
+            self._viewer._request_edit(self)
         self.value_edit.setReadOnly(not checked)
         self.type_label.setVisible(not checked)
         self.type_combo.setVisible(checked)
+        self.delete_button.setVisible(not checked)
         if checked:
-            current_type = self.type_label.text().lower()
+            current_type = self._original_type_text or self.type_label.text().lower()
             if current_type == 'na':
                 current_type = 'none'
             elif current_type == 'non-editable':
                 current_type = 'string'
-            self.type_combo.setCurrentText(current_type)
-            self._apply_value_type_selection(current_type)
+            valid_types = {
+                'number',
+                'string',
+                'bool',
+                'tuple',
+                'list',
+                'dictionary',
+                'none',
+            }
+            if current_type in valid_types:
+                self.type_combo.setCurrentText(current_type)
+                self._apply_value_type_selection(current_type)
+            else:
+                self.type_combo.setCurrentText('string')
+            if not self._confirm_icon.isNull():
+                self.edit_button.setIcon(self._confirm_icon)
+            self._apply_icon(
+                self.delete_button, 'cancel.svg', 'Cancel', QSize(18, 18)
+            )
+            self.delete_button.setToolTip('Cancel edit')
+            self.delete_button.setChecked(True)
+            self.delete_button.setEnabled(True)
+            self.delete_button.setVisible(True)
         else:
-            self._apply_value_type_selection(self.type_combo.currentText())
+            if not self._edit_icon.isNull():
+                self.edit_button.setIcon(self._edit_icon)
+            self._apply_icon(
+                self.delete_button, 'delete.svg', 'Delete', QSize(18, 18)
+            )
+            self.delete_button.setToolTip('Delete')
+            self.delete_button.setChecked(False)
+            if self._discarding:
+                self._discarding = False
+                if self._original_type_text is not None:
+                    self._apply_value_display(self._original_type_text)
+                return
+            self._commit_edit()
+            self._apply_value_display(self.type_combo.currentText())
+            if self._viewer is not None:
+                self._viewer._end_edit(self)
+
+    def _on_cancel_clicked(self) -> None:
+        if not self._editable:
+            return
+        if not self.edit_button.isChecked():
+            return
+        self.discard_edit()
+        self._apply_icon(
+            self.delete_button, 'delete.svg', 'Delete', QSize(18, 18)
+        )
+        if self._viewer is not None:
+            self._viewer._end_edit(self)
 
     def _apply_value_type_selection(self, selected_type: str) -> None:
+        if hasattr(self, 'value_label') and self.value_label is not None:
+            self.value_label.setVisible(False)
         if selected_type in ('string', 'number'):
             self.value_edit.setVisible(True)
+            self.value_edit.setReadOnly(False)
+            if self._bool_combo is not None:
+                self._bool_combo.setVisible(False)
+            if self.value_edit.text() in (
+                'new tuple',
+                'new list',
+                'new dict',
+                'None',
+            ):
+                self.value_edit.setText('')
             self.type_label.setVisible(False)
             return
-        self.value_edit.setVisible(False)
+        if selected_type == 'bool':
+            self.value_edit.setVisible(False)
+            if self._bool_combo is not None:
+                self._bool_combo.setVisible(True)
+                if self._original_value_text in ('True', 'False'):
+                    self._bool_combo.setCurrentText(self._original_value_text)
+            self.type_label.setVisible(False)
+            return
+        self.value_edit.setReadOnly(True)
+        self.value_edit.setVisible(True)
+        if self._bool_combo is not None:
+            self._bool_combo.setVisible(False)
         if selected_type == 'dictionary':
-            label_text = 'dict'
-            label_color = 'gray'
-            label_style = 'font-style: italic;'
+            self.value_edit.setText('new dict')
         elif selected_type == 'tuple':
-            label_text = 'tuple'
-            label_color = 'gray'
-            label_style = 'font-style: italic;'
+            self.value_edit.setText('new tuple')
         elif selected_type == 'list':
-            label_text = 'list'
-            label_color = 'gray'
-            label_style = 'font-style: italic;'
+            self.value_edit.setText('new list')
         else:
-            label_text = 'NA'
-            label_color = 'black'
-            label_style = ''
-        self.type_label.setText(label_text)
-        self.type_label.setStyleSheet(f'color: {label_color}; {label_style}')
-        self.type_label.setVisible(True)
+            self.value_edit.setText('None')
+        self.type_label.setVisible(False)
+
+    def _apply_value_display(self, selected_type: str) -> None:
+        self.value_edit.setReadOnly(True)
+        if selected_type == 'string':
+            self.value_edit.setVisible(True)
+            if self._bool_combo is not None:
+                self._bool_combo.setVisible(False)
+            if hasattr(self, 'value_label') and self.value_label is not None:
+                self.value_label.setVisible(False)
+            self.type_label.setText('string')
+            self.type_label.setStyleSheet('color: #e68c2c;')
+            self.type_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            self.type_label.setVisible(True)
+            self.delete_button.setEnabled(True)
+        elif selected_type == 'other':
+            self.value_edit.setVisible(True)
+            if self._bool_combo is not None:
+                self._bool_combo.setVisible(False)
+            if hasattr(self, 'value_label') and self.value_label is not None:
+                self.value_label.setVisible(False)
+            if self._original_value_text is not None:
+                self.value_edit.setText(self._original_value_text)
+            self.type_label.setText('NE')
+            self.type_label.setStyleSheet('color: gray; font-style: italic;')
+            self.type_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            self.type_label.setVisible(True)
+            self.delete_button.setEnabled(True)
+        elif selected_type == 'number':
+            self.value_edit.setVisible(True)
+            if self._bool_combo is not None:
+                self._bool_combo.setVisible(False)
+            if hasattr(self, 'value_label') and self.value_label is not None:
+                self.value_label.setVisible(False)
+            self.type_label.setText('number')
+            self.type_label.setStyleSheet('color: #4091ed;')
+            self.type_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            self.type_label.setVisible(True)
+            self.delete_button.setEnabled(True)
+        elif selected_type == 'bool':
+            self.value_edit.setVisible(False)
+            if self._bool_combo is not None:
+                self._bool_combo.setVisible(False)
+            if not hasattr(self, 'value_label') or self.value_label is None:
+                self.value_label = QLabel(self)
+                self.value_label.setAlignment(
+                    Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
+                )
+                self._layout.insertWidget(0, self.value_label)
+            label_text = (
+                self._original_value_text
+                if self._original_value_text in ('True', 'False')
+                else 'False'
+            )
+            self.value_label.setText(label_text)
+            self.value_label.setStyleSheet('color: gray; font-style: italic;')
+            self.value_label.setVisible(True)
+            self.type_label.setText('bool')
+            self.type_label.setStyleSheet('color: #bf3be3;')
+            self.type_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            self.type_label.setVisible(True)
+            self.delete_button.setEnabled(True)
+        elif selected_type in ('dictionary', 'tuple', 'list'):
+            self.value_edit.setVisible(False)
+            if self._bool_combo is not None:
+                self._bool_combo.setVisible(False)
+            if not hasattr(self, 'value_label') or self.value_label is None:
+                self.value_label = QLabel(self)
+                self.value_label.setAlignment(
+                    Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
+                )
+                self._layout.insertWidget(0, self.value_label)
+            label_text = (
+                'dict'
+                if selected_type == 'dictionary'
+                else 'tuple'
+                if selected_type == 'tuple'
+                else 'list'
+            )
+            self.value_label.setText(label_text)
+            self.value_label.setStyleSheet('color: gray; font-style: italic;')
+            self.value_label.setVisible(True)
+            self.type_label.setVisible(False)
+            self.delete_button.setEnabled(True)
+        else:
+            self.value_edit.setVisible(True)
+            if self._bool_combo is not None:
+                self._bool_combo.setVisible(False)
+            if hasattr(self, 'value_label') and self.value_label is not None:
+                self.value_label.setVisible(False)
+            self.value_edit.setText('None')
+            self.type_label.setText('NA')
+            self.type_label.setStyleSheet('color: black;')
+            self.type_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            self.type_label.setVisible(True)
+            self.delete_button.setEnabled(False)
+
+    def discard_edit(self) -> None:
+        if not self._editable:
+            return
+        self._discarding = True
+        self.edit_button.setChecked(False)
+        if self._original_value_text is not None:
+            self.value_edit.setText(self._original_value_text)
+        if self._original_type_text is not None:
+            self.type_combo.setCurrentText(self._original_type_text)
+        if self._bool_combo is not None and self._original_value_text in (
+            'True',
+            'False',
+        ):
+            self._bool_combo.setCurrentText(self._original_value_text)
+        self.value_edit.setReadOnly(True)
+        self.type_combo.setVisible(False)
+        if self._original_type_text is not None:
+            self._apply_value_display(self._original_type_text)
+        else:
+            self.type_label.setVisible(True)
+        if not self._edit_icon.isNull():
+            self.edit_button.setIcon(self._edit_icon)
+
+    def _commit_edit(self) -> None:
+        if self._original_value_text is None or self._original_type_text is None:
+            return
+        selected_type = self.type_combo.currentText()
+        if selected_type == 'number':
+            try:
+                float(self.value_edit.text())
+            except ValueError:
+                self.value_edit.setText(self._original_value_text)
+                self.type_combo.setCurrentText(self._original_type_text)
+                return
+        if selected_type == 'bool':
+            if self._bool_combo is not None:
+                self._original_value_text = self._bool_combo.currentText()
+            else:
+                self._original_value_text = 'False'
+            self._original_type_text = 'bool'
+            self._edited = True
+            if self._viewer is not None:
+                self._viewer._recreate_dictionary()
+            return
+        self._original_value_text = self.value_edit.text()
+        self._original_type_text = selected_type
+        self._edited = True
+        if self._viewer is not None:
+            self._viewer._recreate_dictionary()
+
+    def was_edited(self) -> bool:
+        return self._edited
 
     def _apply_icon(
         self,
@@ -651,10 +1297,33 @@ class ValueWidget(QWidget):
             button.setIconSize(icon_size)
         button.setFixedSize(QSize(26, 26))
 
-    def _recreate_dictionary(self) -> None:
-        print('')
-        print('Updating dictionary')
-        return
+    def get_type(self) -> str:
+        if self._original_type_text is None:
+            return 'other'
+        return self._original_type_text
+
+    def get_value(self) -> object:
+        value_type = self.get_type()
+        if value_type == 'none':
+            return None
+        if value_type == 'number':
+            return _parse_number_text(self.value_edit.text())
+        if value_type == 'string':
+            return self.value_edit.text()
+        if value_type == 'bool':
+            text_value = (
+                self._original_value_text
+                if self._original_value_text in ('True', 'False')
+                else self.value_edit.text()
+            )
+            return text_value == 'True'
+        if hasattr(self, 'value_edit'):
+            return self.value_edit.text()
+        if hasattr(self, 'value_label'):
+            return self.value_label.text()
+        return None
+
+
 
 
 def _load_icon(name: str) -> QIcon:
@@ -667,3 +1336,14 @@ def _load_icon(name: str) -> QIcon:
     if not icon_path.is_file():
         return QIcon()
     return QIcon(str(icon_path))
+
+
+def _parse_number_text(text: str) -> int | float | str:
+    try:
+        return int(text)
+    except ValueError:
+        pass
+    try:
+        return float(text)
+    except ValueError:
+        return text

--- a/src/napari_metadata/widgets/_main.py
+++ b/src/napari_metadata/widgets/_main.py
@@ -40,6 +40,7 @@ from napari_metadata.widgets._containers import (
     HorizontalOnlyOuterScrollArea,
     Orientation,
 )
+from napari_metadata.widgets._dict_viewer import MetadataDictViewer
 from napari_metadata.widgets._file import FileGeneralMetadata
 from napari_metadata.widgets._inheritance import InheritanceWidget
 
@@ -85,6 +86,7 @@ class MetadataWidget(QWidget):
             on_apply_inheritance=self.apply_inheritance_to_current_layer,
             parent=self,
         )
+        self._metadata_dict_instance = MetadataDictViewer(napari_viewer, self)
 
         # ── Stacked layout (content + no-layer) ────────────────────
         self._stacked_layout = QStackedLayout()
@@ -113,6 +115,7 @@ class MetadataWidget(QWidget):
         self._file_section: CollapsibleSectionContainer | None = None
         self._axis_section: CollapsibleSectionContainer | None = None
         self._inheritance_section: CollapsibleSectionContainer | None = None
+        self._metadata_dict_section: CollapsibleSectionContainer | None = None
 
         # Start on the no-layer page — no layer is selected at construction
         self._stacked_layout.setCurrentIndex(_NO_LAYER_PAGE)
@@ -237,6 +240,11 @@ class MetadataWidget(QWidget):
             if self._inheritance_section is not None
             else False
         )
+        metadata_dict_expanded = (
+            self._metadata_dict_section.isExpanded()
+            if self._metadata_dict_section is not None
+            else False
+        )
 
         # Detach persistent widgets so they survive container deletion
         self._detach_component_widgets()
@@ -281,6 +289,11 @@ class MetadataWidget(QWidget):
             orientation
         )
         sections_layout.addWidget(self._inheritance_section)
+
+        self._metadata_dict_section = self._build_metadata_dict_section(
+            orientation
+        )
+        sections_layout.addWidget(self._metadata_dict_section)
         sections_layout.addStretch(1)
 
         # Restore expanded states carried over from the previous build so that
@@ -288,6 +301,7 @@ class MetadataWidget(QWidget):
         self._file_section.setExpanded(file_expanded)
         self._axis_section.setExpanded(axis_expanded)
         self._inheritance_section.setExpanded(inheritance_expanded)
+        self._metadata_dict_section.setExpanded(metadata_dict_expanded)
 
         # Keep axis inheritance checkboxes in sync with the rebuilt section's
         # expanded state.
@@ -369,6 +383,22 @@ class MetadataWidget(QWidget):
         container = QWidget(self)
         layout = QGridLayout(container)
         layout.addWidget(self._inheritance_instance)
+        section.set_content_widget(container)
+        return section
+
+    def _build_metadata_dict_section(
+        self, orientation: Orientation
+    ) -> CollapsibleSectionContainer:
+        """Build the metadata dictionary collapsible section."""
+        section = CollapsibleSectionContainer(
+            self,
+            'Metadata dictionary',
+            orientation=orientation,
+        )
+        container = QWidget(self)
+        layout = QVBoxLayout(container)
+        self._metadata_dict_instance.load_layer_dict()
+        layout.addWidget(self._metadata_dict_instance)
         section.set_content_widget(container)
         return section
 

--- a/tests/widgets/test_axis.py
+++ b/tests/widgets/test_axis.py
@@ -158,10 +158,7 @@ class TestAxisUnits:
         units_component.load_entries(layer)
 
         type_combobox = units_component._type_comboboxes[0]
-        string_index = type_combobox.findData(AxisUnitEnum.STRING)
-        assert string_index != -1
-
-        type_combobox.setCurrentIndex(string_index)
+        type_combobox.setCurrentEnum(AxisUnitEnum.STRING)
         units_component._unit_line_edits[0].setText('furlong')
         units_component._unit_line_edits[0].editingFinished.emit()
 
@@ -182,8 +179,7 @@ class TestAxisUnits:
         assert units_component._unit_line_edits[0].isHidden()
 
         type_combobox = units_component._type_comboboxes[0]
-        string_index = type_combobox.findData(AxisUnitEnum.STRING)
-        type_combobox.setCurrentIndex(string_index)
+        type_combobox.setCurrentEnum(AxisUnitEnum.STRING)
 
         assert units_component._unit_comboboxes[0].isHidden()
         assert not units_component._unit_line_edits[0].isHidden()


### PR DESCRIPTION
# References and relevant issues
<!-- What relevant resources were used in the creation of this PR?
If this PR addresses an existing issue on the repo,
please link to that issue here as "Closes #(issue-number)"
If this PR depends on another PR/issue (even in another repo),
please link to it with "Depends on #PR-number" or "Depends on org/repo#PR-number"
-->

This is in relation to Issue #50, which proposes a way to edit the `layer.metadata` dictionary (which the name of the plugin suggests it should be able to do).

A lot of the functions were made/touched by codex.

# Depends on
#100 
Sorry, forgot that I made it from this PR that isn't merged yet. 

# Description
<!-- What does this pull request (PR) do? Is it a new feature, a bug fix,
an improvement, or something else? Why is it necessary? If relevant, please add
a screenshot or a screen capture: "An image is worth a thousand words!" -->

I am creating this draft (Definitely not ready for formal review, this is just a prototype). of how we could do with a `layer.metadata` dictionary access in the plugin. 

It's very unpolished, GUI and code-wise but its just a draft to get ideas from people and see if they think its even worth pursuing. 

I think that because this `layer.metadata` dictionary is very "open", it might not be the best idea to allow for a wide range of edits. Maybe we could limit the edits in some sort of way so to only allow for adding entries to the root of the dictionary or limiting the editing to strings and numbers. 

For now, I allowed a bit more range of edits. There's no connection to listen for metadata changes so you have to change the layer for it to load properly once you set the dictionary. You can also just add an entry if the `layer.metadata` is empty and it'll update in real-time. 

Just be mindful that I set up the basis but asked codex to modify and assist with some functions that I tested but might be a buggy. If you find anything that should not be happening please leave a comment. 

Also, its seems like I didn't set up the key / value spacing so the key section is very small on load. Make sure to expand it. 

1) It allow you to add entries to the dictionary. For simplicity reasons, just numbers and strings is allowed for now. 
Just input both and press the add button. 

2) It allows edits, by pressing the edit button. For both, keys and values. The delete button becomes cancel edit if you're currently editing an entry. 

3) It allows for removing keys and values by pressing the remove button.

4) It can read nested items (lists, dictionaries and tuples).

5) you can add to nested items and edit them.

![metadata_dict_showcase](https://github.com/user-attachments/assets/1cbd71e4-9ac0-4f02-a0b7-795510e44b76)

There's a lot of known issues such as the key section loading very small, the refresh/reconstruction of the QTreeView causing the nested items to collapse and thus the need to reopen them every time you edit.... and many more...

I just want to get input if this is something worth chasing or if it is not something we want. 
 