### PR TITLE
metadata submenu entry

### DIFF
--- a/src/napari_metadata/napari.yaml
+++ b/src/napari_metadata/napari.yaml
@@ -1,10 +1,22 @@
 name: napari-metadata
-display_name: Layer metadata
+display_name: layer metadata
 contributions:
   commands:
     - id: napari-metadata.make_metadata_qwidget
       python_name: napari_metadata.widgets:MetadataWidget
       title: Make metadata widget
+
   widgets:
     - command: napari-metadata.make_metadata_qwidget
       display_name: Layer metadata
+
+  menus:
+    napari/layers:
+      - submenu: metadata
+
+    metadata:
+      - command: napari-metadata.make_metadata_qwidget
+
+  submenus:
+    - id: metadata
+      label: Metadata

--- a/src/napari_metadata/napari.yaml
+++ b/src/napari_metadata/napari.yaml
@@ -1,5 +1,5 @@
 name: napari-metadata
-display_name: layer metadata
+display_name: napari-metadata
 contributions:
   commands:
     - id: napari-metadata.make_metadata_qwidget
@@ -8,15 +8,8 @@ contributions:
 
   widgets:
     - command: napari-metadata.make_metadata_qwidget
-      display_name: Layer metadata
+      display_name: layer metadata
 
   menus:
-    napari/layers:
-      - submenu: metadata
-
-    metadata:
+    napari/layers/metadata:
       - command: napari-metadata.make_metadata_qwidget
-
-  submenus:
-    - id: metadata
-      label: Metadata


### PR DESCRIPTION
# References and relevant issues
Depends on napari/napari#9107
Closes #80

# Description

~~This opts to attempt to add the Layer Metadata widget to `Layers -> Metadata`. However, base submenus are not contributable and there is not a Metadata menu. I think it would be weird to put in transforms (because I could see in many other menus). There needs to be that menu first, so I'm leaving this in `daft` for now~~

Edited by carlos:
This adds the `layer metadata` widget to the newly contributable submenu `Layers > metadata`. It also restores the display name to napari-metadata of the plugin since we'll be adding `viewer metadata` (working title) in the near future.  