### PR TITLE
Fix AxisLabels widget and remove its Qlabel

### DIFF
--- a/src/napari_metadata/widgets/_axis.py
+++ b/src/napari_metadata/widgets/_axis.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING
 
 import pint
 from napari.utils.notifications import show_error
-from qtpy.QtCore import QSignalBlocker, Qt
+from qtpy.QtCore import QSignalBlocker
 from qtpy.QtWidgets import (
     QComboBox,
     QDoubleSpinBox,
@@ -53,10 +53,6 @@ if TYPE_CHECKING:
 class AxisLabels(AxisComponentBase):
     """Per-axis label editor using ``QLineEdit`` widgets.
 
-    Unlike the other axis components, ``AxisLabels`` shows the axis
-    *index* (-3, -2, -1...) in its name label column, because *it* is the
-    widget that edits the axis names.
-
     Parameters
     ----------
     on_labels_changed : callable, optional
@@ -87,10 +83,9 @@ class AxisLabels(AxisComponentBase):
         if ndim == 0:
             return
         for i in range(ndim):
-            # Index label (not the axis name)
-            index_label = QLabel(str(i), parent=self._parent_widget)
-            index_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-            self._axis_name_labels.append(index_label)
+            # Empty label for layout alignment
+            empty_label = QLabel(parent=self._parent_widget)
+            self._axis_name_labels.append(empty_label)
 
             line_edit = QLineEdit(parent=self._parent_widget)
             line_edit.setText(labels[i] if i < len(labels) else '')
@@ -117,7 +112,9 @@ class AxisLabels(AxisComponentBase):
         set_axes_labels(self._napari_viewer, tuple(values))
 
     def update_axis_name_labels(self) -> None:
-        """No-op: AxisLabels shows indices, not axis names."""
+        """Refresh line edits when axis labels change in the layer."""
+        if self._selected_layer is not None:
+            self._refresh_values(self._selected_layer)
 
     def get_line_edit_values(self) -> tuple[str, ...]:
         """Return current text from all label line-edits."""

--- a/src/napari_metadata/widgets/_base.py
+++ b/src/napari_metadata/widgets/_base.py
@@ -107,8 +107,8 @@ class AxisComponentBase(ComponentBase):
     * **Inheritance** — ``inherit_layer_properties`` merges current and
       template layer values based on per-axis checkbox states.
     * **Cross-component sync** — ``update_axis_name_labels`` refreshes
-      the axis-name QLabels from the layer (``AxisLabels`` overrides
-      this to no-op since it *is* the label editor).
+      the axis-name QLabels (or line edits for ``AxisLabels``) from the
+      current layer when axis labels change.
 
     Subclasses must implement the five abstract template methods listed
     below.
@@ -165,8 +165,7 @@ class AxisComponentBase(ComponentBase):
     def update_axis_name_labels(self) -> None:
         """Refresh axis-name ``QLabel`` texts from the current layer.
 
-        ``AxisLabels`` overrides this to no-op because it shows axis
-        *indices*, not axis *names*.
+        ``AxisLabels`` overrides this to refresh its line edits instead.
         """
         labels = get_axes_labels(self._napari_viewer)
         for i, label in enumerate(labels):

--- a/tests/widgets/test_axis.py
+++ b/tests/widgets/test_axis.py
@@ -64,7 +64,7 @@ class TestAxisScales:
 
 
 class TestAxisLabels:
-    def test_shows_index_labels_and_update_is_noop(
+    def test_refreshes_when_layer_axis_labels_change(
         self, viewer_model: ViewerModel, parent_widget: QWidget
     ):
         layer = viewer_model.add_image(
@@ -74,13 +74,18 @@ class TestAxisLabels:
         labels = AxisLabels(viewer_model, parent_widget)
 
         labels.load_entries(layer)
-        assert [lbl.text() for lbl in labels._axis_name_labels] == ['0', '1']
+        assert [lbl.text() for lbl in labels._axis_name_labels] == ['', '']
+        assert [lbl.text() for lbl in labels._line_edits] == ['row', 'col']
 
         layer.axis_labels = ('new_row', 'new_col')
         labels.update_axis_name_labels()
 
-        # AxisLabels intentionally keeps index labels.
-        assert [lbl.text() for lbl in labels._axis_name_labels] == ['0', '1']
+        # AxisLabels should refresh when axis labels change.
+        assert [lbl.text() for lbl in labels._axis_name_labels] == ['', '']
+        assert [lbl.text() for lbl in labels._line_edits] == [
+            'new_row',
+            'new_col',
+        ]
 
 
 class TestAxisMetadataCoordinator:


### PR DESCRIPTION
# References and relevant issues

Discussed in [#community-meeting > 2026-03-05/06 Pacific Community Meeting](https://napari.zulipchat.com/#narrow/channel/215290-community-meeting/topic/2026-03-05.2F06.20Pacific.20Community.20Meeting/with/577693653)

# Description

Removes the Qlabel for each axis's label.
Also fixes a broken no-op because I looked closely at the test and tried to update the test and then it failed, so fixes the widget.

<img width="340" height="253" alt="image" src="https://github.com/user-attachments/assets/dfd7f47b-efc3-465f-911d-c5cc4e5d3e0e" />

