### PR TITLE
Add axis tooltips

### DIFF
--- a/src/napari_metadata/widgets/_axis.py
+++ b/src/napari_metadata/widgets/_axis.py
@@ -56,6 +56,12 @@ class AxisLabels(AxisComponentBase):
     """
 
     _label_text = 'Labels:'
+    # The _tooltip_text is used for the main label of the component
+    _tooltip_text = (
+        'Labels for each of the layer dimensions.<br>Value: string.'
+    )
+    # The _line_edit_tooltip_text is used for the line edits of the axis labels
+    _line_edit_tooltip_text = 'Label for the axis with index '
 
     def __init__(
         self,
@@ -95,7 +101,12 @@ class AxisLabels(AxisComponentBase):
     def get_layout_entries(self, axis_index: int) -> list[LayoutEntry]:
         """Skip the empty axis-name column; span the line edit across all value cols."""
         line_edit = self._line_edits[axis_index]
-        line_edit.setToolTip(self._tooltip_text)
+        number_of_axis = len(self._line_edits)
+        negative_index_number = axis_index - number_of_axis
+        setting_tooltip_text = (
+            self._line_edit_tooltip_text + str(negative_index_number) + '.'
+        )
+        line_edit.setToolTip(setting_tooltip_text)
         return [
             LayoutEntry(widgets=[line_edit], col_span=3),
             LayoutEntry(widgets=[self._inherit_checkboxes[axis_index]]),
@@ -130,6 +141,9 @@ class AxisTranslations(AxisComponentBase):
     """Per-axis translation editor using ``QDoubleSpinBox`` widgets."""
 
     _label_text = 'Translate:'
+    _tooltip_text = (
+        'Translation for each of the layer dimensions.<br>Value: float.'
+    )
 
     def __init__(self, parent_widget: QWidget) -> None:
         super().__init__(parent_widget)
@@ -251,7 +265,6 @@ class AxisUnits(AxisComponentBase):
     """
 
     _label_text = 'Units:'
-    _tooltip_text = 'The Pint unit associated with each axis.'
 
     def __init__(self, parent_widget: QWidget) -> None:
         super().__init__(parent_widget)

--- a/src/napari_metadata/widgets/_axis.py
+++ b/src/napari_metadata/widgets/_axis.py
@@ -56,11 +56,9 @@ class AxisLabels(AxisComponentBase):
     """
 
     _label_text = 'Labels:'
-    # The _tooltip_text is used for the main label of the component
     _tooltip_text = (
         'Labels for each of the layer dimensions.<br>Value: string.'
     )
-    # The _line_edit_tooltip_text is used for the line edits of the axis labels
     _line_edit_tooltip_text = 'Label for the axis with index '
 
     def __init__(
@@ -101,14 +99,16 @@ class AxisLabels(AxisComponentBase):
     def get_layout_entries(self, axis_index: int) -> list[LayoutEntry]:
         """Skip the empty axis-name column; span the line edit across all value cols."""
         line_edit = self._line_edits[axis_index]
-        number_of_axis = len(self._line_edits)
-        negative_index_number = axis_index - number_of_axis
-        setting_tooltip_text = (
-            self._line_edit_tooltip_text + str(negative_index_number) + '.'
-        )
-        line_edit.setToolTip(setting_tooltip_text)
+        value_entries = [
+            LayoutEntry(
+                widgets=[line_edit],
+                col_span=3,
+                tooltips=[self._get_line_edit_tooltip(axis_index)],
+            )
+        ]
+        self._apply_value_entry_tooltips(value_entries)
         return [
-            LayoutEntry(widgets=[line_edit], col_span=3),
+            *value_entries,
             LayoutEntry(widgets=[self._inherit_checkboxes[axis_index]]),
         ]
 
@@ -129,6 +129,11 @@ class AxisLabels(AxisComponentBase):
         """Return current text from all label line-edits."""
         return tuple(le.text() for le in self._line_edits)
 
+    def _get_line_edit_tooltip(self, axis_index: int) -> str:
+        """Return the tooltip text for one axis-label line edit."""
+        axis_number = self._get_axis_number(axis_index)
+        return f'{self._line_edit_tooltip_text}{axis_number}.'
+
     def _on_editing_finished(self) -> None:
         """Handle editingFinished from any label QLineEdit."""
         labels = self.get_line_edit_values()
@@ -143,6 +148,9 @@ class AxisTranslations(AxisComponentBase):
     _label_text = 'Translate:'
     _tooltip_text = (
         'Translation for each of the layer dimensions.<br>Value: float.'
+    )
+    _spinbox_tooltip_text = (
+        'Translation for the axis with index {axis_number}.<br>Value: float.'
     )
 
     def __init__(self, parent_widget: QWidget) -> None:
@@ -174,7 +182,16 @@ class AxisTranslations(AxisComponentBase):
                     self._spinboxes[i].setValue(value)
 
     def _get_value_entries(self, axis_index: int) -> list[LayoutEntry]:
-        return [LayoutEntry(widgets=[self._spinboxes[axis_index]], col_span=2)]
+        axis_number = self._get_axis_number(axis_index)
+        return [
+            LayoutEntry(
+                widgets=[self._spinboxes[axis_index]],
+                col_span=2,
+                tooltips=[
+                    self._spinbox_tooltip_text.format(axis_number=axis_number)
+                ],
+            )
+        ]
 
     def _get_layer_values(self, layer: Layer) -> tuple:
         return tuple(layer.translate)
@@ -198,6 +215,8 @@ class AxisScales(AxisComponentBase):
     _SCALE_MINIMUM = 0.001
 
     _label_text = 'Scale:'
+    _tooltip_text = 'Scale for each of the layer dimensions.<br>Value: float.'
+    _spinbox_tooltip_text = 'Scale for the axis with index {axis_number}.<br>The value needs to be more than 0.<br>Value: float.'
 
     def __init__(self, parent_widget: QWidget) -> None:
         super().__init__(parent_widget)
@@ -231,7 +250,16 @@ class AxisScales(AxisComponentBase):
                     self._spinboxes[i].setValue(value)
 
     def _get_value_entries(self, axis_index: int) -> list[LayoutEntry]:
-        return [LayoutEntry(widgets=[self._spinboxes[axis_index]], col_span=2)]
+        axis_number = self._get_axis_number(axis_index)
+        return [
+            LayoutEntry(
+                widgets=[self._spinboxes[axis_index]],
+                col_span=2,
+                tooltips=[
+                    self._spinbox_tooltip_text.format(axis_number=axis_number)
+                ],
+            )
+        ]
 
     def _get_layer_values(self, layer: Layer) -> tuple:
         return tuple(layer.scale)
@@ -265,6 +293,14 @@ class AxisUnits(AxisComponentBase):
     """
 
     _label_text = 'Units:'
+    _tooltip_text = 'Units for each of the layer dimensions.<br>Unit types per dimension order in all open layers must match to apply them in rendering.'
+    _type_combobox_tooltip_text = (
+        'Unit category for the axis with index {axis_number}.'
+    )
+    _unit_combobox_tooltip_text = (
+        'Preset unit for the axis with index {axis_number}.'
+    )
+    _unit_line_edit_tooltip_text = 'Custom unit for the axis with index {axis_number}.<br>The input string must be a valid pint unit.'
 
     def __init__(self, parent_widget: QWidget) -> None:
         super().__init__(parent_widget)
@@ -339,13 +375,29 @@ class AxisUnits(AxisComponentBase):
         self._sync_visibilities()
 
     def _get_value_entries(self, axis_index: int) -> list[LayoutEntry]:
+        axis_number = self._get_axis_number(axis_index)
         return [
-            LayoutEntry(widgets=[self._type_comboboxes[axis_index]]),
+            LayoutEntry(
+                widgets=[self._type_comboboxes[axis_index]],
+                tooltips=[
+                    self._type_combobox_tooltip_text.format(
+                        axis_number=axis_number
+                    )
+                ],
+            ),
             LayoutEntry(
                 widgets=[
                     self._unit_comboboxes[axis_index],
                     self._unit_line_edits[axis_index],
-                ]
+                ],
+                tooltips=[
+                    self._unit_combobox_tooltip_text.format(
+                        axis_number=axis_number
+                    ),
+                    self._unit_line_edit_tooltip_text.format(
+                        axis_number=axis_number
+                    ),
+                ],
             ),
         ]
 

--- a/src/napari_metadata/widgets/_base.py
+++ b/src/napari_metadata/widgets/_base.py
@@ -50,12 +50,16 @@ class LayoutEntry:
         Number of grid columns.
     alignment : Qt.AlignmentFlag
         Hint for alignment inside the cell.
+    tooltips : list[str] | None
+        Optional tooltip text per widget in ``widgets``. When omitted,
+        axis components fall back to their component-level tooltip text.
     """
 
     widgets: list[QWidget]
     row_span: int = 1
     col_span: int = 1
     alignment: Qt.AlignmentFlag = Qt.AlignmentFlag.AlignVCenter
+    tooltips: list[str] | None = None
 
 
 class ComponentBase(ABC):
@@ -228,9 +232,7 @@ class AxisComponentBase(BoundLayerOwner, ComponentBase):
             LayoutEntry(widgets=[self._axis_name_labels[axis_index]]),
         ]
         value_entries = self._get_value_entries(axis_index)
-        for entry in value_entries:
-            for widget in entry.widgets:
-                widget.setToolTip(self._tooltip_text)
+        self._apply_value_entry_tooltips(value_entries)
         entries.extend(value_entries)
         entries.append(
             LayoutEntry(widgets=[self._inherit_checkboxes[axis_index]]),
@@ -313,6 +315,29 @@ class AxisComponentBase(BoundLayerOwner, ComponentBase):
         base lists.
         """
         return [self._axis_name_labels, self._inherit_checkboxes]
+
+    def _apply_value_entry_tooltips(
+        self, entries: list[LayoutEntry]
+    ) -> None:
+        """Apply per-widget tooltips to value entries.
+
+        Entries without explicit ``tooltips`` metadata fall back to the
+        component-level tooltip text.
+        """
+        for entry in entries:
+            tooltips = entry.tooltips
+            if tooltips is None:
+                tooltips = [self._tooltip_text] * len(entry.widgets)
+            if len(tooltips) != len(entry.widgets):
+                raise ValueError(
+                    'LayoutEntry.tooltips must match the number of widgets.'
+                )
+            for widget, tooltip in zip(entry.widgets, tooltips, strict=True):
+                widget.setToolTip(tooltip)
+
+    def _get_axis_number(self, axis_index: int) -> int:
+        """Return the negative napari-style index for *axis_index*."""
+        return axis_index - self.num_axes
 
     def _clear_widgets(self) -> None:
         """Block signals and destroy all per-axis widgets.

--- a/src/napari_metadata/widgets/_base.py
+++ b/src/napari_metadata/widgets/_base.py
@@ -316,9 +316,7 @@ class AxisComponentBase(BoundLayerOwner, ComponentBase):
         """
         return [self._axis_name_labels, self._inherit_checkboxes]
 
-    def _apply_value_entry_tooltips(
-        self, entries: list[LayoutEntry]
-    ) -> None:
+    def _apply_value_entry_tooltips(self, entries: list[LayoutEntry]) -> None:
         """Apply per-widget tooltips to value entries.
 
         Entries without explicit ``tooltips`` metadata fall back to the

--- a/tests/widgets/test_axis.py
+++ b/tests/widgets/test_axis.py
@@ -126,7 +126,10 @@ class TestAxisLabels:
 
         entries = labels.get_layout_entries(0)
 
-        assert entries[0].widgets[0].toolTip() == 'Label for the axis with index -2.'
+        assert (
+            entries[0].widgets[0].toolTip()
+            == 'Label for the axis with index -2.'
+        )
 
 
 class TestAxisTranslations:

--- a/tests/widgets/test_axis.py
+++ b/tests/widgets/test_axis.py
@@ -368,7 +368,7 @@ class TestAxisUnits:
         )
         assert (
             entries[2].widgets[1].toolTip()
-            == 'Custom unit for the axis with index -2.'
+            == 'Custom unit for the axis with index -2.<br>The input string must be a valid pint unit.'
         )
 
 

--- a/tests/widgets/test_axis.py
+++ b/tests/widgets/test_axis.py
@@ -117,6 +117,17 @@ class TestAxisLabels:
 
         assert labels.get_line_edit_values() == ('row', 'col')
 
+    def test_get_layout_entries_applies_axis_specific_tooltip(
+        self, parent_widget: QWidget
+    ):
+        layer = _make_layer(axis_labels=('y', 'x'))
+        labels = AxisLabels(parent_widget)
+        labels.load_entries(layer)
+
+        entries = labels.get_layout_entries(0)
+
+        assert entries[0].widgets[0].toolTip() == 'Label for the axis with index -2.'
+
 
 class TestAxisTranslations:
     def test_spinbox_value_change_writes_to_layer(
@@ -140,6 +151,20 @@ class TestAxisTranslations:
 
         assert translations._spinboxes[0].value() == pytest.approx(10.0)
         assert translations._spinboxes[1].value() == pytest.approx(20.0)
+
+    def test_get_layout_entries_applies_axis_specific_tooltip(
+        self, parent_widget: QWidget
+    ):
+        layer = _make_layer(translate=(0.0, 0.0))
+        translations = AxisTranslations(parent_widget)
+        translations.load_entries(layer)
+
+        entries = translations.get_layout_entries(1)
+
+        assert (
+            entries[1].widgets[0].toolTip()
+            == 'Translation for the axis with index -1.<br>Value: float.'
+        )
 
 
 class TestAxisMetadataCoordinator:
@@ -320,6 +345,28 @@ class TestAxisUnits:
 
         assert str(layer.units[0]) == AxisUnitEnum.SPACE.value.default
         assert units_component._unit_comboboxes[0].currentText() == 'pixel'
+
+    def test_get_layout_entries_applies_tooltips_to_all_unit_widgets(
+        self, parent_widget: QWidget
+    ):
+        layer = _make_layer(units=('pixel', 'second'))
+        units_component = AxisUnits(parent_widget)
+        units_component.load_entries(layer)
+
+        entries = units_component.get_layout_entries(0)
+
+        assert (
+            entries[1].widgets[0].toolTip()
+            == 'Unit category for the axis with index -2.'
+        )
+        assert (
+            entries[2].widgets[0].toolTip()
+            == 'Preset unit for the axis with index -2.'
+        )
+        assert (
+            entries[2].widgets[1].toolTip()
+            == 'Custom unit for the axis with index -2.'
+        )
 
 
 class TestAxisEventDriven:

--- a/tests/widgets/test_base.py
+++ b/tests/widgets/test_base.py
@@ -261,6 +261,17 @@ class _DummyAxisComponent(AxisComponentBase):
         layer.translate = tuple(values)
 
 
+class _DummyAxisComponentWithExplicitTooltips(_DummyAxisComponent):
+    def _get_value_entries(self, axis_index: int) -> list[LayoutEntry]:
+        line_edit = self._value_line_edits[axis_index]
+        return [
+            LayoutEntry(
+                widgets=[line_edit],
+                tooltips=[f'Explicit tooltip {axis_index}.'],
+            )
+        ]
+
+
 class TestLayoutEntry:
     def test_defaults(self):
         entry = LayoutEntry(widgets=[])
@@ -338,6 +349,39 @@ class TestAxisComponentBaseLifecycle:
             for widget in entries[1].widgets:
                 assert widget.toolTip() == 'Axis tooltip.'
             assert entries[2].widgets[0].toolTip() == ''
+
+    def test_get_layout_entries_uses_explicit_entry_tooltips(
+        self, parent_widget: QWidget
+    ):
+        layer = Image(np.zeros((4, 3)))
+        component = _DummyAxisComponentWithExplicitTooltips(parent_widget)
+        component.load_entries(layer)
+
+        entries = component.get_layout_entries(1)
+
+        assert entries[1].widgets[0].toolTip() == 'Explicit tooltip 1.'
+
+    def test_get_layout_entries_raises_on_tooltip_widget_count_mismatch(
+        self, parent_widget: QWidget
+    ):
+        class _InvalidTooltipComponent(_DummyAxisComponent):
+            def _get_value_entries(self, axis_index: int) -> list[LayoutEntry]:
+                return [
+                    LayoutEntry(
+                        widgets=[self._value_line_edits[axis_index]],
+                        tooltips=['one', 'two'],
+                    )
+                ]
+
+        layer = Image(np.zeros((4, 3)))
+        component = _InvalidTooltipComponent(parent_widget)
+        component.load_entries(layer)
+
+        with pytest.raises(
+            ValueError,
+            match='LayoutEntry.tooltips must match the number of widgets.',
+        ):
+            component.get_layout_entries(0)
 
 
 class TestAxisComponentBaseHelpers:


### PR DESCRIPTION
# References and relevant issues
#109 

# Description
In this draft PR, I'm proposing a system to add tooltips to the axis metadata widgets, not just the labels. 

It does get a little complicated. We have to modify the `LayoutEntry` class that is being passed to the orientation constructor but it gets the job done. 

I asked codex to help me out a little bit with the implementation. I think its decent but I'm still not very happy with it. Maybe we can take a look and discuss about it?

This allows, for example. To display the corresponding axis index in the tooltip by doing simple string replacements and passing different values to different widgets such as the ones in the `units` entries where you have three different possible QWidgets and all of them with different tooltips now. 
