### PR TITLE
Enh: Layer size -- uncompressed, lazy, remote -- and file size fixes

### DIFF
--- a/src/napari_metadata/file_size.py
+++ b/src/napari_metadata/file_size.py
@@ -3,25 +3,32 @@ metadata stored with the image (e.g. name, scale). Instead, it is
 a property which is populated on the fly at runtime.
 """
 
+from __future__ import annotations
+
 import logging
 import math
-import urllib
+import urllib.parse
 from pathlib import Path
 from typing import Union
 
 from napari.layers import Layer
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
+
+# URL schemes that indicate a remote (non-local) data source.
+_REMOTE_SCHEMES = frozenset(
+    {'http', 'https', 's3', 'gs', 'gcs', 'az', 'abfs', 'ftp', 'ftps'}
+)
 
 
 def _generate_text_for_size(size: Union[int, float], suffix: str = '') -> str:
     """Generate the text for the file size widget. Consumes size in bytes,
     reduces the order of magnitude and appends the units. Optionally adds
-    an addition suffix to the end of the string.
+    an additional suffix to the end of the string.
 
-    >>> generate_text_for_size(13)
+    >>> _generate_text_for_size(13)
     '13.00 bytes'
-    >>> generate_text_for_size(1303131, suffix=' (in memory)')
+    >>> _generate_text_for_size(1303131, suffix=' (in memory)')
     '1.30 MB (in memory)'
 
     Parameters
@@ -29,7 +36,7 @@ def _generate_text_for_size(size: Union[int, float], suffix: str = '') -> str:
     size: (int | float)
         The size in bytes
     suffix: (str, optional)
-        Addition text suffix to add to the display. Defaults to ''.
+        Additional text suffix to add to the display. Defaults to ''.
 
     Returns
     -------
@@ -50,47 +57,129 @@ def _generate_text_for_size(size: Union[int, float], suffix: str = '') -> str:
     return f'{text}{suffix}'
 
 
-def generate_display_size(layer: Layer) -> str:
-    """High level generator for the displayed file size text on the widget.
-    If the provided layer has a source path, it will read the memory size on
-    disk. If there is no source path on the layer, it will use the size of
-    the data array.
+def _is_remote_path(path: str | None) -> bool:
+    """Return True if *path* is a remote URL.
+
+    Recognises common cloud and web schemes (http, https, s3, gs, az, …).
+    Single-character schemes are treated as Windows drive letters and are
+    therefore considered local.
 
     Parameters
     ----------
-    layer: napari.Layer
-        Napari Layer for which to generate file size text
+    path : str | None
+        The source path from ``layer.source.path``.
+    """
+    if not path:
+        return False
+    scheme = urllib.parse.urlparse(str(path)).scheme.lower()
+    # Windows drive letters (e.g. 'C' in 'C:\\...') are single characters.
+    if len(scheme) <= 1:
+        return False
+    return scheme in _REMOTE_SCHEMES
+
+
+def _is_lazy_data(data: object) -> bool:
+    """Return True if *data* is a lazy/deferred array (e.g. dask.array.Array).
+
+    Avoids importing dask at module level; returns False if dask is not installed.
+    """
+    try:
+        import dask.array as da
+
+        return isinstance(data, da.Array)
+    except ImportError:  # pragma: no cover
+        return False
+
+
+def _has_lazy_data(layer: Layer) -> bool:
+    """Return True if any data component of *layer* is a lazy/dask array."""
+    if type(layer).__name__ in ('Shapes', 'Surface') or getattr(
+        layer, 'multiscale', False
+    ):
+        return any(_is_lazy_data(d) for d in layer.data)
+    return _is_lazy_data(layer.data)
+
+
+def _get_napari_size(layer: Layer) -> int:
+    """Return the uncompressed in-napari size of *layer* in bytes.
+
+    For lazy (dask) arrays this is the *theoretical* fully-loaded size, not
+    the currently-resident memory footprint.  For multiscale, Shapes and
+    Surface layers the per-component sizes are summed.
+    """
+    if type(layer).__name__ in ('Shapes', 'Surface') or getattr(
+        layer, 'multiscale', False
+    ):
+        return sum(getattr(d, 'nbytes', 0) for d in layer.data)
+    return layer.data.nbytes
+
+
+def _get_stored_size(path: str) -> int | None:
+    """Return the on-disk size of a local file or directory in bytes.
+
+    Returns ``None`` if *path* does not exist or cannot be read.
+    """
+    try:
+        p = Path(path)
+        if p.is_dir():
+            return sum(f.stat().st_size for f in p.rglob('*') if f.is_file())
+        if p.is_file():
+            return p.stat().st_size
+    except OSError:
+        logger.debug('Could not read stored size for %s', path)
+    return None
+
+
+def generate_display_size(layer: Layer) -> str:
+    """Generate a display string describing the size of *layer*.
+
+    Two size values are reported when possible:
+
+    * **Stored size** — compressed size of the data on local disk (file or
+      directory, e.g. a zarr store).  Omitted for remote sources and
+      purely in-memory layers.
+    * **Napari size** — uncompressed, dtype-based size of the layer data.
+      For lazy (dask) arrays this is the theoretical fully-loaded footprint,
+      marked ``(uncompressed, lazy)``.  For in-memory numpy arrays it is the
+      actual allocation, marked ``(in memory)``.
+
+    Parameters
+    ----------
+    layer : napari.layers.Layer
+        The layer to describe.
 
     Returns
     -------
     str
-        Formatted string for the file size or size in memory of the data.
-    """
-    is_url = urllib.parse.urlparse(layer.source.path).scheme in (
-        'http',
-        'https',
-    )
-    # data exists in file on disk
-    if layer.source.path and not is_url:
-        p = Path(layer.source.path)
-        if p.is_dir():
-            size = sum(
-                file.stat().st_size for file in p.rglob('*') if file.is_file()
-            )
-        else:
-            size = p.stat().st_size
-        suffix = ''
-    # data exists only in memory
-    else:
-        if (
-            type(layer).__name__ == 'Shapes'
-            or type(layer).__name__ == 'Surface'
-            or layer.multiscale is True
-        ):
-            size = sum(d.nbytes for d in layer.data)
-        else:
-            size = layer.data.nbytes
-        suffix = ' (in memory)'
-    text = _generate_text_for_size(size, suffix=suffix)
+        A formatted string, for example:
 
-    return text
+        ``"18.00 MB (on disk) / 3.00 GB (uncompressed)"``   — local .tif
+        ``"4.20 MB (on disk) / 17.00 GB (uncompressed, lazy)"``  — local zarr
+        ``"17.00 GB (uncompressed, lazy)"``                  — remote zarr
+        ``"100.00 MB (in memory)"``                          — pure in-memory
+    """
+    path = layer.source.path
+    is_remote = _is_remote_path(path)
+    has_local_source = bool(path) and not is_remote
+    is_lazy = _has_lazy_data(layer)
+
+    napari_size = _get_napari_size(layer)
+
+    if is_lazy:
+        napari_suffix = ' (uncompressed, lazy)'
+    elif has_local_source or is_remote:
+        napari_suffix = ' (uncompressed)'
+    else:
+        napari_suffix = ' (in memory)'
+
+    napari_text = _generate_text_for_size(napari_size, suffix=napari_suffix)
+
+    if has_local_source:
+        stored_size = _get_stored_size(path)
+        if stored_size is not None:
+            stored_text = _generate_text_for_size(
+                stored_size, suffix=' (on disk)'
+            )
+            return f'{stored_text} / {napari_text}'
+
+    return napari_text

--- a/src/napari_metadata/widgets/_file.py
+++ b/src/napari_metadata/widgets/_file.py
@@ -109,7 +109,7 @@ class LayerDataType(FileComponentBase):
 class FileSize(FileComponentBase):
     """Read-only file/memory size display."""
 
-    _label_text = 'File Size:'
+    _label_text = 'Layer Size:'
 
     def _get_display_text(self, layer: Layer) -> str:
         return str(generate_display_size(layer))

--- a/tests/test_file_size.py
+++ b/tests/test_file_size.py
@@ -5,9 +5,15 @@ from unittest.mock import MagicMock
 
 import napari.layers
 import numpy as np
+import pytest
 
 from napari_metadata.file_size import (
     _generate_text_for_size,
+    _get_napari_size,
+    _get_stored_size,
+    _has_lazy_data,
+    _is_lazy_data,
+    _is_remote_path,
     generate_display_size,
 )
 
@@ -43,16 +49,161 @@ class TestGenerateTextForSize:
         assert '(in memory)' not in result
 
 
+class TestIsRemotePath:
+    def test_none_is_not_remote(self):
+        assert _is_remote_path(None) is False
+
+    def test_empty_string_is_not_remote(self):
+        assert _is_remote_path('') is False
+
+    def test_http_is_remote(self):
+        assert _is_remote_path('http://example.com/data.zarr') is True
+
+    def test_https_is_remote(self):
+        assert _is_remote_path('https://example.com/data.zarr') is True
+
+    def test_s3_is_remote(self):
+        assert _is_remote_path('s3://bucket/data.zarr') is True
+
+    def test_gcs_is_remote(self):
+        assert _is_remote_path('gs://bucket/data.zarr') is True
+
+    def test_abfs_is_remote(self):
+        assert _is_remote_path('abfs://container/data.zarr') is True
+
+    def test_ftp_is_remote(self):
+        assert _is_remote_path('ftp://example.com/data.zarr') is True
+
+    def test_windows_drive_is_not_remote(self):
+        assert _is_remote_path('C:\\Users\\user\\data.tif') is False
+
+    def test_unix_absolute_path_is_not_remote(self):
+        assert _is_remote_path('/home/user/data.tif') is False
+
+    def test_file_scheme_is_not_remote(self):
+        assert _is_remote_path('file:///home/user/data.tif') is False
+
+    def test_relative_path_is_not_remote(self):
+        assert _is_remote_path('data/test.tif') is False
+
+
+class TestIsLazyData:
+    def test_numpy_array_is_not_lazy(self):
+        assert _is_lazy_data(np.zeros((5, 5))) is False
+
+    def test_dask_array_is_lazy(self):
+        dask = pytest.importorskip('dask.array')
+        assert _is_lazy_data(dask.zeros((5, 5))) is True
+
+    def test_list_is_not_lazy(self):
+        assert _is_lazy_data([1, 2, 3]) is False
+
+    def test_none_is_not_lazy(self):
+        assert _is_lazy_data(None) is False
+
+
+class TestHasLazyData:
+    def test_numpy_image_is_not_lazy(self):
+        layer = napari.layers.Image(np.zeros((10, 10), dtype=np.uint8))
+        assert _has_lazy_data(layer) is False
+
+    def test_dask_image_is_lazy(self):
+        dask = pytest.importorskip('dask.array')
+        layer = napari.layers.Image(dask.zeros((10, 10), dtype=np.uint8))
+        assert _has_lazy_data(layer) is True
+
+    def test_multiscale_numpy_is_not_lazy(self):
+        scales = [np.zeros((20, 20)), np.zeros((10, 10))]
+        layer = napari.layers.Image(scales, multiscale=True)
+        assert _has_lazy_data(layer) is False
+
+    def test_multiscale_dask_is_lazy(self):
+        dask = pytest.importorskip('dask.array')
+        scales = [dask.zeros((20, 20)), dask.zeros((10, 10))]
+        layer = napari.layers.Image(scales, multiscale=True)
+        assert _has_lazy_data(layer) is True
+
+
+class TestGetStoredSize:
+    def test_single_file(self, tmp_path):
+        f = tmp_path / 'test.npy'
+        np.save(f, np.zeros((10, 10), dtype=np.uint8))
+        assert _get_stored_size(str(f)) == f.stat().st_size
+
+    def test_directory(self, tmp_path):
+        d = tmp_path / 'data'
+        d.mkdir()
+        f1 = d / 'a.npy'
+        f2 = d / 'b.npy'
+        np.save(f1, np.zeros((10, 10), dtype=np.uint8))
+        np.save(f2, np.zeros((10, 10), dtype=np.uint8))
+        expected = f1.stat().st_size + f2.stat().st_size
+        assert _get_stored_size(str(d)) == expected
+
+    def test_nested_directory(self, tmp_path):
+        d = tmp_path / 'data'
+        sub = d / 'sub'
+        sub.mkdir(parents=True)
+        f1 = d / 'a.npy'
+        f2 = sub / 'b.npy'
+        np.save(f1, np.zeros((10, 10), dtype=np.uint8))
+        np.save(f2, np.zeros((10, 10), dtype=np.uint8))
+        expected = f1.stat().st_size + f2.stat().st_size
+        assert _get_stored_size(str(d)) == expected
+
+    def test_nonexistent_path_returns_none(self, tmp_path):
+        assert _get_stored_size(str(tmp_path / 'nonexistent.tif')) is None
+
+
+class TestGetNapariSize:
+    def test_simple_image(self):
+        data = np.zeros((10, 10), dtype=np.uint8)
+        layer = napari.layers.Image(data)
+        assert _get_napari_size(layer) == data.nbytes
+
+    def test_uint32_image(self):
+        data = np.zeros((10, 10), dtype=np.uint32)
+        layer = napari.layers.Image(data)
+        assert _get_napari_size(layer) == data.nbytes
+
+    def test_multiscale_image_sums_all_scales(self):
+        scales = [
+            np.zeros((20, 20), dtype=np.uint8),
+            np.zeros((10, 10), dtype=np.uint8),
+        ]
+        layer = napari.layers.Image(scales, multiscale=True)
+        assert _get_napari_size(layer) == sum(s.nbytes for s in scales)
+
+    def test_shapes_layer(self):
+        shape_data = [np.array([[0, 0], [1, 1], [1, 0]], dtype=np.float32)]
+        layer = napari.layers.Shapes(shape_data, shape_type='polygon')
+        assert _get_napari_size(layer) == sum(d.nbytes for d in layer.data)
+
+    def test_surface_layer(self):
+        vertices = np.array(
+            [[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32
+        )
+        faces = np.array([[0, 1, 2]], dtype=np.int32)
+        layer = napari.layers.Surface((vertices, faces))
+        assert _get_napari_size(layer) == sum(d.nbytes for d in layer.data)
+
+    def test_dask_image_reports_theoretical_size(self):
+        dask = pytest.importorskip('dask.array')
+        data = dask.zeros((100, 100), dtype=np.uint32, chunks=(50, 50))
+        layer = napari.layers.Image(data)
+        assert _get_napari_size(layer) == data.nbytes
+
+
 class TestGenerateDisplaySize:
-    def test_in_memory_image(self):
+    # ── In-memory layers ────────────────────────────────────────────────────
+
+    def test_in_memory_image_shows_in_memory_suffix(self):
         data = np.zeros((10, 10), dtype=np.uint8)
         layer = napari.layers.Image(data)
         result = generate_display_size(layer)
-        assert result == _generate_text_for_size(
-            data.nbytes, suffix=' (in memory)'
-        )
+        assert result == _generate_text_for_size(data.nbytes, ' (in memory)')
 
-    def test_in_memory_multiscale_image(self):
+    def test_in_memory_multiscale_shows_in_memory_suffix(self):
         scales = [
             np.zeros((20, 20), dtype=np.uint8),
             np.zeros((10, 10), dtype=np.uint8),
@@ -85,31 +236,58 @@ class TestGenerateDisplaySize:
             expected_size, suffix=' (in memory)'
         )
 
-    def test_from_disk_path(self, tmp_path):
+    def test_in_memory_suffix_present(self):
+        data = np.zeros((4, 4), dtype=np.uint8)
+        layer = napari.layers.Image(data)
+        result = generate_display_size(layer)
+        assert '(in memory)' in result
+        assert '(on disk)' not in result
+
+    def test_in_memory_dask_shows_lazy_suffix(self):
+        dask = pytest.importorskip('dask.array')
+        data = dask.zeros((50, 50), dtype=np.uint8, chunks=(25, 25))
+        layer = napari.layers.Image(data)
+        result = generate_display_size(layer)
+        assert '(uncompressed, lazy)' in result
+        assert '(in memory)' not in result
+        assert '(on disk)' not in result
+
+    # ── Local file/directory layers ─────────────────────────────────────────
+
+    def test_from_disk_single_file_shows_both_sizes(self, tmp_path):
         data = np.zeros((10, 10), dtype=np.uint8)
         file_path = tmp_path / 'test.npy'
         np.save(file_path, data)
         layer = MagicMock(spec=napari.layers.Image)
         layer.source.path = str(file_path)
+        layer.data = data
+        layer.multiscale = False
         result = generate_display_size(layer)
-        expected_size = os.path.getsize(str(file_path))
-        assert result == _generate_text_for_size(expected_size)
+        stored_size = os.path.getsize(str(file_path))
+        assert _generate_text_for_size(stored_size, ' (on disk)') in result
+        assert (
+            _generate_text_for_size(data.nbytes, ' (uncompressed)') in result
+        )
         assert '(in memory)' not in result
+        assert '(lazy)' not in result
 
-    def test_from_disk_directory(self, tmp_path):
+    def test_from_disk_directory_shows_both_sizes(self, tmp_path):
         dir_path = tmp_path / 'test_dir'
         dir_path.mkdir()
-        file1 = dir_path / 'a.npy'
-        file2 = dir_path / 'b.npy'
-        np.save(file1, np.zeros((10, 10), dtype=np.uint8))
-        np.save(file2, np.zeros((20, 20), dtype=np.uint8))
+        f1 = dir_path / 'a.npy'
+        f2 = dir_path / 'b.npy'
+        data1 = np.zeros((10, 10), dtype=np.uint8)
+        data2 = np.zeros((20, 20), dtype=np.uint8)
+        np.save(f1, data1)
+        np.save(f2, data2)
+        combined = np.concatenate([data1.ravel(), data2.ravel()])
         layer = MagicMock(spec=napari.layers.Image)
         layer.source.path = str(dir_path)
+        layer.data = combined
+        layer.multiscale = False
         result = generate_display_size(layer)
-        expected_size = os.path.getsize(str(file1)) + os.path.getsize(
-            str(file2)
-        )
-        assert result == _generate_text_for_size(expected_size)
+        stored_size = os.path.getsize(str(f1)) + os.path.getsize(str(f2))
+        assert _generate_text_for_size(stored_size, ' (on disk)') in result
         assert '(in memory)' not in result
 
     def test_from_disk_directory_with_subdirectory(self, tmp_path):
@@ -117,22 +295,90 @@ class TestGenerateDisplaySize:
         dir_path.mkdir()
         sub_dir = dir_path / 'sub_dir'
         sub_dir.mkdir()
-        file1 = dir_path / 'a.npy'
-        file2 = sub_dir / 'b.npy'
-        np.save(file1, np.zeros((10, 10), dtype=np.uint8))
-        np.save(file2, np.zeros((20, 20), dtype=np.uint8))
+        f1 = dir_path / 'a.npy'
+        f2 = sub_dir / 'b.npy'
+        np.save(f1, np.zeros((10, 10), dtype=np.uint8))
+        np.save(f2, np.zeros((20, 20), dtype=np.uint8))
+        data = np.zeros((10, 10), dtype=np.uint8)
         layer = MagicMock(spec=napari.layers.Image)
         layer.source.path = str(dir_path)
+        layer.data = data
+        layer.multiscale = False
         result = generate_display_size(layer)
-        expected_size = os.path.getsize(str(file1)) + os.path.getsize(
-            str(file2)
-        )
-        assert result == _generate_text_for_size(expected_size)
+        stored_size = os.path.getsize(str(f1)) + os.path.getsize(str(f2))
+        assert _generate_text_for_size(stored_size, ' (on disk)') in result
+
+    def test_from_disk_lazy_dask_shows_lazy_suffix(self, tmp_path):
+        """Local zarr-like directory opened as dask array shows both sizes."""
+        dask = pytest.importorskip('dask.array')
+        dir_path = tmp_path / 'zarr_store'
+        dir_path.mkdir()
+        f = dir_path / 'chunk.npy'
+        np.save(f, np.zeros((10, 10), dtype=np.uint32))
+        data = dask.zeros((100, 100), dtype=np.uint32, chunks=(50, 50))
+        layer = MagicMock(spec=napari.layers.Image)
+        layer.source.path = str(dir_path)
+        layer.data = data
+        layer.multiscale = False
+        result = generate_display_size(layer)
+        assert '(on disk)' in result
+        assert '(uncompressed, lazy)' in result
         assert '(in memory)' not in result
 
-    def test_in_memory_suffix_present(self):
-        # data is not on disk, so in memory will be appended
-        data = np.zeros((4, 4), dtype=np.uint8)
-        layer = napari.layers.Image(data)
+    # ── Remote layers ────────────────────────────────────────────────────────
+
+    def test_remote_https_numpy_shows_uncompressed(self):
+        data = np.zeros((10, 10), dtype=np.uint8)
+        layer = MagicMock(spec=napari.layers.Image)
+        layer.source.path = 'https://example.com/data.zarr'
+        layer.data = data
+        layer.multiscale = False
         result = generate_display_size(layer)
-        assert '(in memory)' in result
+        assert result == _generate_text_for_size(
+            data.nbytes, ' (uncompressed)'
+        )
+        assert '(in memory)' not in result
+        assert '(on disk)' not in result
+
+    def test_remote_https_dask_shows_lazy_suffix(self):
+        """This is the case from issue #140: remote zarr must not say 'in memory'."""
+        dask = pytest.importorskip('dask.array')
+        data = dask.zeros(
+            (1000, 1000, 100), dtype=np.uint16, chunks=(100, 100, 10)
+        )
+        layer = MagicMock(spec=napari.layers.Image)
+        layer.source.path = 'https://example.com/ome.zarr'
+        layer.data = data
+        layer.multiscale = False
+        result = generate_display_size(layer)
+        assert '(uncompressed, lazy)' in result
+        assert '(in memory)' not in result
+        assert '(on disk)' not in result
+
+    def test_remote_s3_dask_shows_lazy_suffix(self):
+        dask = pytest.importorskip('dask.array')
+        data = dask.zeros((50, 50), dtype=np.float32, chunks=(25, 25))
+        layer = MagicMock(spec=napari.layers.Image)
+        layer.source.path = 's3://my-bucket/data.zarr'
+        layer.data = data
+        layer.multiscale = False
+        result = generate_display_size(layer)
+        assert '(uncompressed, lazy)' in result
+        assert '(in memory)' not in result
+        assert '(on disk)' not in result
+
+    def test_remote_multiscale_dask_shows_lazy_suffix(self):
+        """Multiscale remote zarr (napari-ome-zarr use case) — issue #140."""
+        dask = pytest.importorskip('dask.array')
+        scales = [
+            dask.zeros((200, 200), dtype=np.uint16, chunks=(100, 100)),
+            dask.zeros((100, 100), dtype=np.uint16, chunks=(50, 50)),
+        ]
+        layer = MagicMock(spec=napari.layers.Image)
+        layer.source.path = 'https://example.com/ome.zarr'
+        layer.data = scales
+        layer.multiscale = True
+        result = generate_display_size(layer)
+        assert '(uncompressed, lazy)' in result
+        assert '(in memory)' not in result
+        assert '(on disk)' not in result


### PR DESCRIPTION
# References and relevant issues

Closes #140

# Description

Instead of thinking of the metadata as "file size" we should try to think of it as layer size... I'm not super sold on the GUI aspect of this presentation yet.

But, we also need to account for
1. remote
2. uncompressed size vs local size
3. lazy
4. multiscale

Representation in RAM is different than on disk / remote