### PR TITLE
Bump superqt dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "numpy",
     "qtpy",
     "pint",
-    "superqt",
+    "superqt>=0.8.2",
     "typing_extensions",  # only needed for python 3.10 import of Self
 ]
 dynamic = ["version"]


### PR DESCRIPTION
# References and relevant issues
pyapp-kit/superqt#341

# Description
The QToggleButtons need an update to 0.8.2 in superqt to update correctly in the new `Viewer metadata` class
